### PR TITLE
was failing to compile linux - error: unknown type name ‘uint16_t’

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SRC = $(wildcard $(COMPILER_DIR)*.c) \
 INCLUDE = -I$(COMPILER_DIR) -I$(RUNTIME_DIR) -I$(SHARED_DIR) -I$(UTILS_DIR) 
 CFLAGS = $(INCLUDE) -O2
 OBJ = $(SRC:.c=.o)
-LDFLAGS = 
+LDFLAGS = -lm
 
 all: unittest gravity
 

--- a/src/compiler/gravity_token.h
+++ b/src/compiler/gravity_token.h
@@ -9,6 +9,8 @@
 #ifndef __GRAVITY_TOKEN__
 #define __GRAVITY_TOKEN__
 
+#include <stdint.h>
+
 #include "debug_macros.h"
 
 //	================

--- a/src/shared/gravity_array.h
+++ b/src/shared/gravity_array.h
@@ -9,6 +9,8 @@
 #ifndef __GRAVITY_MUTABLE_ARRAY__
 #define __GRAVITY_MUTABLE_ARRAY__
 
+#include <stdint.h> 
+
 // Inspired by https://github.com/attractivechaos/klib/blob/master/kvec.h
 
 #define MARRAY_DEFAULT_SIZE			8


### PR DESCRIPTION
just added header and a linker math library to fix make compile errors

after these changes was able to successfully compile on 

64 bit  Ubuntu 16.04 
gcc version 5.4.1 20160904 (Ubuntu 5.4.1-2ubuntu1~16.04) 
