### PR TITLE
Some Grammar Fixes in the Docs

### DIFF
--- a/docs/classes.html
+++ b/docs/classes.html
@@ -76,7 +76,7 @@
          	<h1 class="section-header">Class</h1><hr>
 			
 			<p class="section-content">
-			Every value in Gravity is an object, and every object is an instance of a class. Classes define an objects behavior and state. Behavior is defined by methods which live in the class. Every object of the same class supports the same methods. State is defined in fields, whose values are stored in each instance.<br><br>Like <a href="functions.html">functions</a> a <strong>Class is a first class object</strong>, that means that it can be stored in local variables (even in <a href="list.html">Lists</a> or <a href="map.html">Maps</a>), passed as a function parameter or returned by a function. Gravity supports <strong>nested classes</strong> and <strong>single inheritance</strong>.
+			Every value in Gravity is an object, and every object is an instance of a class. Classes define an object's behavior and state. Behavior is defined by methods which live in the class. Every object of the same class supports the same methods. State is defined in fields, whose values are stored in each instance.<br><br>Like <a href="functions.html">functions</a> a <strong>Class is a first class object</strong>, that means that it can be stored in local variables (even in <a href="list.html">Lists</a> or <a href="map.html">Maps</a>), passed as a function parameter or returned by a function. Gravity supports <strong>nested classes</strong> and <strong>single inheritance</strong>.
 			</p>
 			
 			<h4 class="section-h4">Defining a class</h4>
@@ -87,7 +87,7 @@
 			</code></pre>
 			
 			<h4 class="section-h4">Instantiate a class</h4>
-			<p>A class in gravity can be instantiated simply executing it (without the new keyword):</p>
+			<p>A class in gravity can be instantiated by simply executing it (without the new keyword):</p>
 			<pre><code class="swift">
 	var instance = Italy();
 			</code></pre>

--- a/docs/enum.html
+++ b/docs/enum.html
@@ -113,7 +113,7 @@
 		var d = mixed.four;	// d = true 
 	}
 			</code></pre>
-			<p>Enum is a static operator, it means that at compile time the real value of the enum item is automatically replaced by Gravity.</p>
+			<p>Enum is a static operator, which means that at compile time the real value of the enum item is automatically replaced by Gravity.</p>
          	</div>
        	</div> <!-- /row -->
        </div> <!-- /main-content -->

--- a/docs/functions.html
+++ b/docs/functions.html
@@ -76,7 +76,7 @@
          	<h1 class="section-header">Function</h1><hr>
 			
 			<p class="section-content">
-			Functions are first class objects like <a href="types.html">Int</a> or <a href="types.html">String</a> and can be stored in local variables (even in <a href="list.html">Lists</a> or <a href="map.html">Maps</a>), passed as function parameters or returned by a function. Functions can be implemented in Gravity or in a <a href="api.html">native language</a> with calling conventions compatible with ANSI C.<br><br>Functions are called by value, this means that foo(1) calls the function which is the value of the variable foo. Calling a value that is not a function will raise a runtime error.
+			Functions are first class objects like <a href="types.html">Int</a> or <a href="types.html">String</a> and can be stored in local variables (even in <a href="list.html">Lists</a> or <a href="map.html">Maps</a>), passed as function parameters or returned by a function. Functions can be implemented in Gravity or in a <a href="api.html">native language</a> with calling conventions compatible with ANSI C.<br><br>Functions are called by value. This means that foo(1) calls the function which is the value of the variable foo. Calling a value that is not a function will raise a runtime error.
 			</p>
 			<pre><code class="swift">
 	func main() {

--- a/docs/lists.html
+++ b/docs/lists.html
@@ -111,7 +111,7 @@
 			</code></pre>
 			
 			<h4 class="section-h4">Adding elements</h4>
-			<p>A List instance can be expanded by setting an index greater than current list size:</p> 
+			<p>A List instance can be expanded by setting an index that is greater than the current size of the list:</p>
 			<pre><code class="swift">
 	var list = [10,20,30,40,50];
 	list[30] = 22;	// list contains now 31 elements (index 0...30)

--- a/docs/lists.html
+++ b/docs/lists.html
@@ -86,7 +86,7 @@
 			</code></pre>
 			
 			<h4 class="section-h4">Accessing elements</h4>
-			<p>You can access an element from a list by calling the subscript operator [] on it with the index of the element you want. Like most languages, indexes start at zero:
+			<p>You can access an element from a list by calling the subscript operator [] on it with the index of the element you want. Like most languages, indices start at zero:
 			</p>
 			<pre><code class="swift">
 	var names = ["Mark", "Andrew", "Paul", "Ross", "Frank", "Max"];

--- a/docs/loops.html
+++ b/docs/loops.html
@@ -115,7 +115,7 @@
 	}
 	return count;
 			</code></pre>
-			<p>The for in loop can be used over any object that support iteration like <a href="lists.html">Lists</a> or <a href="maps.html">Maps</a>.</p>
+			<p>The for in loop can be used over any object that supports iteration, such as <a href="lists.html">Lists</a> or <a href="maps.html">Maps</a>.</p>
          	
          	<h4 class="section-h4">Loop method</h4>
          	<p>Performing a loop is very common operation in any programming language, so Gravity adds a very convenient way to run a loop by adding a special loop method to some classes (Int, Range, List and Map) that accepts a <a href="closures.html">closure</a> as parameter:</p>

--- a/docs/loops.html
+++ b/docs/loops.html
@@ -107,7 +107,7 @@
 			</code></pre>
 			
 			<h4 class="section-h4">For loop</h4>
-			<p>You can access an element from a list by calling the subscript operator [] on it with the index of the element you want. Like most languages, indexes start at zero:</p>
+			<p>You can access an element from a list by calling the subscript operator [] on it with the index of the element you want. Like most languages, indices start at zero:</p>
 			<pre><code class="swift">
 	var count = 0;
 	for (var i in 0...40) {

--- a/docs/maps.html
+++ b/docs/maps.html
@@ -109,7 +109,7 @@
 			</code></pre>
 			
 			<h4 class="section-h4">Adding elements</h4>
-			<p>An item can be added to a map simply settings a key/value:</p>
+			<p>An item can be added to a map by simply setting a key/value:</p>
 			<pre><code class="swift">
 	var people = ["Mark":1, "Andrew":2, "Paul":3, "Ross":4];
 	people["Kiara"] = 5;	// people now contains the "Kiara" key with value 5

--- a/docs/syntax.html
+++ b/docs/syntax.html
@@ -79,7 +79,7 @@
 			<p class="section-content">
 			<strong>Gravity</strong> syntax is designed to be familiar to people coming from C-like languages like Javascript, Swift, C++, C# and many more. We started working on this new language a year before Apple announced Swift and we were happily surprised to discovered how similar both syntax appear. Semicolon separator <strong>;</strong> is optional.
 			<br><br>
-			How a Gravity program looks like:</p>
+			How a Gravity program looks:</p>
 			<pre><code class="swift">
 	class Rectangle {
 		// instance variables
@@ -135,7 +135,7 @@
 			
 			<!-- IDENTIFIERS -->
 			<h4 class="section-h4">Identifiers</h4>
-			<p>Identifiers represent a naming rule used to identifies objects inside your source code.
+			<p>Identifiers represent a naming rule used to identify objects inside your source code.
 			Gravity is a case-sensitive language. Identifiers start with a letter or underscore and may contain letters, digits, and underscores (function identifiers can be any of the <a href="operators.html">built-in operators</a> in order to override a default behaviour):</p>
 			<pre><code class="swift">
 	a
@@ -147,7 +147,7 @@
 			
 			<!-- BLOCKS -->
 			<h4 class="section-h4">Blocks and Scope</h4>
-			<p>Every named identifier introduced in some portion of the source code is introduced in a scope. The scope is the largest part of the source code in which that identifier is valid. The names declared by a declaration are introduced into a specific scope based on the context of the declaration. For instance, local variable declarations introduce the name into the block scope, whereas class member variable declarations introduce the name into class scope.<br><br>There are three scopes defined: <strong>block scope</strong>, <strong>class scope</strong> and <strong>file scope</strong>. Names declared at block become visible immediately after its completed declarator.  This means you cannot refer to a name within block until after it has been fully declared. Names declared at file and class scope become visible immediately upon executing the starting statement of the script. This means you can refer to a name within file or class scope before it has been fully declared.<br><br>These are all valid scopes:</p>
+			<p>Every named identifier introduced in some portion of the source code is introduced in a scope. The scope is the largest part of the source code in which that identifier is valid. The names declared by a declaration are introduced into a specific scope based on the context of the declaration. For instance, local variable declarations introduce the name into the block scope, whereas class member variable declarations introduce the name into class scope.<br><br>There are three scopes defined: <strong>block scope</strong>, <strong>class scope</strong> and <strong>file scope</strong>. Names declared in the block scope become visible immediately after its completed declarator.  This means you cannot refer to a name within the block scope until after it has been fully declared. Names declared in the file and class scopes become visible immediately upon executing the starting statement of the script. This means you can refer to a name within the file or class scopes before it has been fully declared.<br><br>These are all valid scopes:</p>
 			<pre><code class="swift">
 	// file scope can refer to a name
 	// before it has been fully declared

--- a/docs/unit-test.html
+++ b/docs/unit-test.html
@@ -78,7 +78,7 @@
          	<h1 class="section-header">Unit Test</h1><hr>
          				
 			<p class="section-content">
-				Unit testing is so important (expecially for a programming language) that Gravity has built-in unit testing capabilities. What user needs to do is to setup some delegate C methods in order to be able to correctly setup a unit-test. Gravity already has a unit-test executable so in order to add your code to it you need to create a .gravity file using the special #unittest preprocessor macro:</p>
+				Unit testing is so important (expecially for a programming language) that Gravity has built-in unit testing capabilities. What a user needs to do is setup some delegate C methods in order to be able to correctly setup a unit-test. Gravity already has a unit-test executable so in order to add your code to it you need to create a .gravity file using the special #unittest preprocessor macro:</p>
 			<pre><code class="swift">
 #unittest {
 	name: "A simple add operation.";


### PR DESCRIPTION
Just a few grammatical fixes I made in the docs.

As for the "indices" vs "indexes", while both words are correct plural forms of index, it is probably best to keep it consistent, so I just changed two instances of "indexes" to "indices"