### PR TITLE
Added "gravity" and "unittest" executables to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@
 *.i*86
 *.x86_64
 *.hex
+gravity
+unittest
 
 # Debug files
 *.dSYM/


### PR DESCRIPTION
These generated executables probably should be in the gitignore.

Up to you though.