### PR TITLE
_int64 does not exist but __int64 on WIN32

### DIFF
--- a/src/utils/gravity_utils.h
+++ b/src/utils/gravity_utils.h
@@ -13,7 +13,7 @@
 #include <stdbool.h>
 
 #if defined(_WIN32)
-typedef unsigned _int64 nanotime_t;
+typedef unsigned __int64 nanotime_t;
 #define DIRREF			HANDLE
 #else
 #include <dirent.h>


### PR DESCRIPTION
Otherwise it does not compile on WIN32.