### PR TITLE
Added vim syntax highlighting.

### DIFF
--- a/syntax_highlighting/vim/ftdetect/gravity.vim
+++ b/syntax_highlighting/vim/ftdetect/gravity.vim
@@ -1,0 +1,32 @@
+" Copyright (c) 2014 Keith Smiley (http://keith.so)
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the 'Software'), to deal
+" in the Software without restriction, including without limitation the rights
+" to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+" copies of " the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+
+" The above copyright notice and this permission notice shall be included in all
+" copies or substantial portions of the Software.
+
+" THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+" OUT OF OR IN " CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+" THE SOFTWARE.
+
+
+autocmd BufNewFile,BufRead *.gravity set filetype=gravity
+autocmd BufRead * call s:Gravity()
+function! s:Gravity()
+  if !empty(&filetype)
+    return
+  endif
+
+  let line = getline(1)
+  if line =~ "^#!.*gravity"
+    setfiletype gravity
+  endif
+endfunction

--- a/syntax_highlighting/vim/indent/gravity.vim
+++ b/syntax_highlighting/vim/indent/gravity.vim
@@ -1,0 +1,257 @@
+" Copyright (c) 2014 Keith Smiley (http://keith.so)
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the 'Software'), to deal
+" in the Software without restriction, including without limitation the rights
+" to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+" copies of " the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+
+" The above copyright notice and this permission notice shall be included in all
+" copies or substantial portions of the Software.
+
+" THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+" OUT OF OR IN " CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+" THE SOFTWARE.
+
+" File: gravity.vim
+" Author: Keith Smiley
+" Description: The indent file for Gravity
+" Last Modified: December 05, 2014
+
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal nosmartindent
+setlocal indentkeys-=e
+setlocal indentkeys+=0]
+setlocal indentexpr=GravityIndent()
+
+function! s:NumberOfMatches(char, string, index)
+  let instances = 0
+  let i = 0
+  while i < strlen(a:string)
+    if a:string[i] == a:char && !s:IsExcludedFromIndentAtPosition(a:index, i + 1)
+      let instances += 1
+    endif
+
+    let i += 1
+  endwhile
+
+  return instances
+endfunction
+
+function! s:SyntaxNameAtPosition(line, column)
+  return synIDattr(synID(a:line, a:column, 0), "name")
+endfunction
+
+function! s:SyntaxName()
+  return s:SyntaxNameAtPosition(line("."), col("."))
+endfunction
+
+function! s:IsExcludedFromIndentAtPosition(line, column)
+  let name = s:SyntaxNameAtPosition(a:line, a:column)
+  return name ==# "gravityComment" || name ==# "gravityString"
+endfunction
+
+function! s:IsExcludedFromIndent()
+  return s:SyntaxName() ==# "gravityComment" || s:SyntaxName() ==# "gravityString"
+endfunction
+
+function! s:IsCommentLine(lnum)
+    return synIDattr(synID(a:lnum,
+          \     match(getline(a:lnum), "\S") + 1, 0), "name")
+          \ ==# "gravityComment"
+endfunction
+
+function! GravityIndent(...)
+  let clnum = a:0 ? a:1 : v:lnum
+
+  let line = getline(clnum)
+  let previousNum = prevnonblank(clnum - 1)
+  while s:IsCommentLine(previousNum) != 0
+    let previousNum = prevnonblank(previousNum - 1)
+  endwhile
+
+  let previous = getline(previousNum)
+  let cindent = cindent(clnum)
+  let previousIndent = indent(previousNum)
+
+  let numOpenParens = s:NumberOfMatches("(", previous, previousNum)
+  let numCloseParens = s:NumberOfMatches(")", previous, previousNum)
+  let numOpenBrackets = s:NumberOfMatches("{", previous, previousNum)
+  let numCloseBrackets = s:NumberOfMatches("}", previous, previousNum)
+
+  let currentOpenBrackets = s:NumberOfMatches("{", line, clnum)
+  let currentCloseBrackets = s:NumberOfMatches("}", line, clnum)
+
+  let numOpenSquare = s:NumberOfMatches("[", previous, previousNum)
+  let numCloseSquare = s:NumberOfMatches("]", previous, previousNum)
+
+  let currentCloseSquare = s:NumberOfMatches("]", line, clnum)
+  if numOpenSquare > numCloseSquare && currentCloseSquare < 1
+    return previousIndent + shiftwidth()
+  endif
+
+  if currentCloseSquare > 0 && line !~ '\v\[.*\]'
+    let column = col(".")
+    call cursor(line("."), 1)
+    let openingSquare = searchpair("\\[", "", "\\]", "bWn", "s:IsExcludedFromIndent()")
+    call cursor(line("."), column)
+
+    if openingSquare == 0
+      return -1
+    endif
+
+    " - Line starts with closing square, indent as opening square
+    if line =~ '\v^\s*]'
+      return indent(openingSquare)
+    endif
+
+    " - Line contains closing square and more, indent a level above opening
+    return indent(openingSquare) + shiftwidth()
+  endif
+
+  if line =~ ":$"
+    let switch = search("switch", "bWn")
+    return indent(switch)
+  elseif previous =~ ":$"
+    return previousIndent + shiftwidth()
+  endif
+
+  if numOpenParens == numCloseParens
+    if numOpenBrackets > numCloseBrackets
+      if currentCloseBrackets > currentOpenBrackets || line =~ "\\v^\\s*}"
+        let column = col(".")
+        call cursor(line("."), 1)
+        let openingBracket = searchpair("{", "", "}", "bWn", "s:IsExcludedFromIndent()")
+        call cursor(line("."), column)
+        if openingBracket == 0
+          return -1
+        else
+          return indent(openingBracket)
+        endif
+      endif
+
+      return previousIndent + shiftwidth()
+    elseif previous =~ "}.*{"
+      if line =~ "\\v^\\s*}"
+        return previousIndent
+      endif
+
+      return previousIndent + shiftwidth()
+    elseif line =~ "}.*{"
+      let openingBracket = searchpair("{", "", "}", "bWn", "s:IsExcludedFromIndent()")
+      return indent(openingBracket)
+    elseif currentCloseBrackets > currentOpenBrackets
+      let column = col(".")
+      call cursor(line("."), 1)
+      let openingBracket = searchpair("{", "", "}", "bWn", "s:IsExcludedFromIndent()")
+      call cursor(line("."), column)
+
+      let bracketLine = getline(openingBracket)
+
+      let numOpenParensBracketLine = s:NumberOfMatches("(", bracketLine, openingBracket)
+      let numCloseParensBracketLine = s:NumberOfMatches(")", bracketLine, openingBracket)
+      if numCloseParensBracketLine > numOpenParensBracketLine
+        let line = line(".")
+        let column = col(".")
+        call cursor(openingParen, column)
+        let openingParen = searchpair("(", "", ")", "bWn", "s:IsExcludedFromIndent()")
+        call cursor(line, column)
+        return indent(openingParen)
+      endif
+      return indent(openingBracket)
+    else
+      " - Current line is blank, and the user presses 'o'
+      return previousIndent
+    endif
+  endif
+
+  if numCloseParens > 0
+    if currentOpenBrackets > 0 || currentCloseBrackets > 0
+      if currentOpenBrackets > 0
+        if numOpenBrackets > numCloseBrackets
+          return previousIndent + shiftwidth()
+        endif
+
+        if line =~ "}.*{"
+          let openingBracket = searchpair("{", "", "}", "bWn", "s:IsExcludedFromIndent()")
+          return indent(openingBracket)
+        endif
+
+        if numCloseParens > numOpenParens
+          let line = line(".")
+          let column = col(".")
+          call cursor(line - 1, column)
+          let openingParen = searchpair("(", "", ")", "bWn", "s:IsExcludedFromIndent()")
+          call cursor(line, column)
+          return indent(openingParen)
+        endif
+
+        return previousIndent
+      endif
+
+      if currentCloseBrackets > 0
+        let openingBracket = searchpair("{", "", "}", "bWn", "s:IsExcludedFromIndent()")
+        return indent(openingBracket)
+      endif
+
+      return cindent
+    endif
+
+    if numCloseParens < numOpenParens
+      if numOpenBrackets > numCloseBrackets
+        return previousIndent + shiftwidth()
+      endif
+
+      let previousParen = match(previous, "(")
+      return indent(previousParen) + shiftwidth()
+    endif
+
+    if numOpenBrackets > numCloseBrackets
+      let line = line(".")
+      let column = col(".")
+      call cursor(previousNum, column)
+      let openingParen = searchpair("(", "", ")", "bWn", "s:IsExcludedFromIndent()")
+      call cursor(line, column)
+      return indent(openingParen) + shiftwidth()
+    endif
+
+    " - Previous line has close then open braces, indent previous + 1 'sw'
+    if previous =~ "}.*{"
+      return previousIndent + shiftwidth()
+    endif
+
+    let line = line(".")
+    let column = col(".")
+    call cursor(previousNum, column)
+    let openingParen = searchpair("(", "", ")", "bWn", "s:IsExcludedFromIndent()")
+    call cursor(line, column)
+
+    return indent(openingParen)
+  endif
+
+  " - Line above has (unmatched) open paren, next line needs indent
+  if numOpenParens > 0
+    let savePosition = getcurpos()
+    " Must be at EOL because open paren has to be above (left of) the cursor
+    call cursor(previousNum, col("$"))
+    let previousParen = searchpair("(", "", ")", "bWn", "s:IsExcludedFromIndent()")
+    call setpos(".", savePosition)
+    return indent(previousParen) + shiftwidth()
+  endif
+
+  return cindent
+endfunction
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/syntax_highlighting/vim/syntax/gravity.vim
+++ b/syntax_highlighting/vim/syntax/gravity.vim
@@ -1,0 +1,304 @@
+" Copyright (c) 2014 Keith Smiley (http://keith.so)
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the 'Software'), to deal
+" in the Software without restriction, including without limitation the rights
+" to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+" copies of " the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+
+" The above copyright notice and this permission notice shall be included in all
+" copies or substantial portions of the Software.
+
+" THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+" OUT OF OR IN " CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+" THE SOFTWARE.
+
+" File: gravity.vim
+" Author: Keith Smiley
+" Description: Runtime files for Gravity
+" Last Modified: June 15, 2014
+
+if exists("b:current_syntax")
+  finish
+endif
+
+" Comments
+" Shebang
+syntax match gravityShebang "\v#!.*$"
+
+" Comment contained keywords
+syntax keyword gravityTodos contained TODO XXX FIXME NOTE
+syntax keyword gravityMarker contained MARK
+
+" In comment identifiers
+function! s:CommentKeywordMatch(keyword)
+  execute "syntax match gravityDocString \"\\v^\\s*-\\s*". a:keyword . "\\W\"hs=s+1,he=e-1 contained"
+endfunction
+
+syntax case ignore
+
+call s:CommentKeywordMatch("attention")
+call s:CommentKeywordMatch("author")
+call s:CommentKeywordMatch("authors")
+call s:CommentKeywordMatch("bug")
+call s:CommentKeywordMatch("complexity")
+call s:CommentKeywordMatch("copyright")
+call s:CommentKeywordMatch("date")
+call s:CommentKeywordMatch("experiment")
+call s:CommentKeywordMatch("important")
+call s:CommentKeywordMatch("invariant")
+call s:CommentKeywordMatch("note")
+call s:CommentKeywordMatch("parameter")
+call s:CommentKeywordMatch("postcondition")
+call s:CommentKeywordMatch("precondition")
+call s:CommentKeywordMatch("remark")
+call s:CommentKeywordMatch("remarks")
+call s:CommentKeywordMatch("requires")
+call s:CommentKeywordMatch("returns")
+call s:CommentKeywordMatch("see")
+call s:CommentKeywordMatch("since")
+call s:CommentKeywordMatch("throws")
+call s:CommentKeywordMatch("todo")
+call s:CommentKeywordMatch("version")
+call s:CommentKeywordMatch("warning")
+
+syntax case match
+delfunction s:CommentKeywordMatch
+
+
+" Literals
+" Strings
+syntax region gravityString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=gravityInterpolatedWrapper oneline
+syntax region gravityInterpolatedWrapper start="\v[^\\]\zs\\\(\s*" end="\v\s*\)" contained containedin=gravityString contains=gravityInterpolatedString,gravityString oneline
+syntax match gravityInterpolatedString "\v\w+(\(\))?" contained containedin=gravityInterpolatedWrapper oneline
+
+" Numbers
+syntax match gravityNumber "\v<\d+>"
+syntax match gravityNumber "\v<(\d+_+)+\d+(\.\d+(_+\d+)*)?>"
+syntax match gravityNumber "\v<\d+\.\d+>"
+syntax match gravityNumber "\v<\d*\.?\d+([Ee]-?)?\d+>"
+syntax match gravityNumber "\v<0x[[:xdigit:]_]+([Pp]-?)?\x+>"
+syntax match gravityNumber "\v<0b[01_]+>"
+syntax match gravityNumber "\v<0o[0-7_]+>"
+
+" BOOLs
+syntax keyword gravityBoolean
+      \ true
+      \ false
+
+
+" Operators
+syntax match gravityOperator "\v\~"
+syntax match gravityOperator "\v\s+!"
+syntax match gravityOperator "\v\%"
+syntax match gravityOperator "\v\^"
+syntax match gravityOperator "\v\&"
+syntax match gravityOperator "\v\*"
+syntax match gravityOperator "\v-"
+syntax match gravityOperator "\v\+"
+syntax match gravityOperator "\v\="
+syntax match gravityOperator "\v\|"
+syntax match gravityOperator "\v\/"
+syntax match gravityOperator "\v\."
+syntax match gravityOperator "\v\<"
+syntax match gravityOperator "\v\>"
+syntax match gravityOperator "\v\?\?"
+
+" Methods/Functions/Properties
+syntax match gravityMethod "\(\.\)\@<=\w\+\((\)\@="
+syntax match gravityProperty "\(\.\)\@<=\<\w\+\>(\@!"
+
+" Gravity closure arguments
+syntax match gravityClosureArgument "\$\d\+\(\.\d\+\)\?"
+
+syntax match gravityAvailability "\v((\*(\s*,\s*[a-zA-Z="0-9.]+)*)|(\w+\s+\d+(\.\d+(.\d+)?)?\s*,\s*)+\*)" contains=gravityString
+syntax keyword gravityPlatforms OSX iOS watchOS OSXApplicationExtension iOSApplicationExtension contained containedin=gravityAvailability
+syntax keyword gravityAvailabilityArg renamed unavailable introduced deprecated obsoleted message contained containedin=gravityAvailability
+
+" Keywords {{{
+syntax keyword gravityKeywords
+      \ associatedtype
+      \ associativity
+      \ atexit
+      \ break
+      \ case
+      \ catch
+      \ class
+      \ continue
+      \ convenience
+      \ default
+      \ defer
+      \ deinit
+      \ didSet
+      \ do
+      \ dynamic
+      \ else
+      \ extension
+      \ fallthrough
+      \ fileprivate
+      \ final
+      \ for
+      \ func
+      \ get
+      \ guard
+      \ if
+      \ import
+      \ in
+      \ infix
+      \ init
+      \ inout
+      \ internal
+      \ lazy
+      \ let
+      \ mutating
+      \ nil
+      \ nonmutating
+      \ operator
+      \ optional
+      \ override
+      \ postfix
+      \ precedence
+      \ precedencegroup
+      \ prefix
+      \ private
+      \ protocol
+      \ public
+      \ repeat
+      \ required
+      \ rethrows
+      \ return
+      \ self
+      \ set
+      \ static
+      \ subscript
+      \ super
+      \ switch
+      \ throw
+      \ throws
+      \ try
+      \ typealias
+      \ unowned
+      \ var
+      \ weak
+      \ where
+      \ while
+      \ willSet
+
+syntax match gravityMultiwordKeywords "indirect case"
+syntax match gravityMultiwordKeywords "indirect enum"
+" }}}
+
+" Names surrounded by backticks. This aren't limited to keywords because 1)
+" Gravity doesn't limit them to keywords and 2) I couldn't make the keywords not
+" highlight at the same time
+syntax region gravityEscapedReservedWord start="`" end="`" oneline
+
+syntax keyword gravityAttributes
+      \ @assignment
+      \ @autoclosure
+      \ @available
+      \ @convention
+      \ @discardableResult
+      \ @exported
+      \ @IBAction
+      \ @IBDesignable
+      \ @IBInspectable
+      \ @IBOutlet
+      \ @noescape
+      \ @nonobjc
+      \ @noreturn
+      \ @NSApplicationMain
+      \ @NSCopying
+      \ @NSManaged
+      \ @objc
+      \ @testable
+      \ @UIApplicationMain
+      \ @warn_unused_result
+
+syntax keyword gravityConditionStatement #available
+
+syntax keyword gravityStructure
+      \ struct
+      \ enum
+
+syntax keyword gravityDebugIdentifier
+      \ #column
+      \ #file
+      \ #function
+      \ #line
+      \ __COLUMN__
+      \ __FILE__
+      \ __FUNCTION__
+      \ __LINE__
+
+syntax keyword gravityLineDirective #setline
+
+syntax region gravityTypeWrapper start="\v:\s*" skip="\s*,\s*$*\s*" end="$\|/"me=e-1 contains=ALLBUT,gravityInterpolatedWrapper transparent
+syntax region gravityTypeCastWrapper start="\(as\|is\)\(!\|?\)\=\s\+" end="\v(\s|$|\{)" contains=gravityType,gravityCastKeyword keepend transparent oneline
+syntax region gravityGenericsWrapper start="\v\<" end="\v\>" contains=gravityType transparent oneline
+syntax region gravityLiteralWrapper start="\v\=\s*" skip="\v[^\[\]]\(\)" end="\v(\[\]|\(\))" contains=ALL transparent oneline
+syntax region gravityReturnWrapper start="\v-\>\s*" end="\v(\{|$)" contains=gravityType transparent oneline
+syntax match gravityType "\v<\u\w*" contained containedin=gravityTypeWrapper,gravityLiteralWrapper,gravityGenericsWrapper,gravityTypeCastWrapper
+
+syntax keyword gravityImports import
+syntax keyword gravityCastKeyword is as contained
+
+" 'preprocesor' stuff
+syntax keyword gravityPreprocessor
+      \ #if
+      \ #elseif
+      \ #else
+      \ #endif
+      \ #selector
+
+
+" Comment patterns
+syntax match gravityComment "\v\/\/.*$"
+      \ contains=gravityTodos,gravityDocString,gravityMarker,@Spell oneline
+syntax region gravityComment start="/\*" end="\*/"
+      \ contains=gravityTodos,gravityDocString,gravityMarker,gravityComment,@Spell fold
+
+
+" Set highlights
+highlight default link gravityTodos Todo
+highlight default link gravityDocString String
+highlight default link gravityShebang Comment
+highlight default link gravityComment Comment
+highlight default link gravityMarker Comment
+
+highlight default link gravityString String
+highlight default link gravityInterpolatedWrapper Delimiter
+highlight default link gravityNumber Number
+highlight default link gravityBoolean Boolean
+
+highlight default link gravityOperator Operator
+highlight default link gravityCastKeyword Keyword
+highlight default link gravityKeywords Keyword
+highlight default link gravityMultiwordKeywords Keyword
+highlight default link gravityEscapedReservedWord Normal
+highlight default link gravityClosureArgument Operator
+highlight default link gravityAttributes PreProc
+highlight default link gravityConditionStatement PreProc
+highlight default link gravityStructure Structure
+highlight default link gravityType Type
+highlight default link gravityImports Include
+highlight default link gravityPreprocessor PreProc
+highlight default link gravityMethod Function
+highlight default link gravityProperty Identifier
+
+highlight default link gravityConditionStatement PreProc
+highlight default link gravityAvailability Normal
+highlight default link gravityAvailabilityArg Normal
+highlight default link gravityPlatforms Keyword
+highlight default link gravityDebugIdentifier PreProc
+highlight default link gravityLineDirective PreProc
+
+" Force vim to sync at least x lines. This solves the multiline comment not
+" being highlighted issue
+syn sync minlines=100
+
+let b:current_syntax = "gravity"


### PR DESCRIPTION
Reference #26 and #23 for syntax highlighting.

This is copied from

* https://github.com/keith/swift.vim

The original author requires that copyright notice to be in his work
when used elsewhere.

Also, this is unmodified (except for substitutions of "swift" with "gravity",
so it is actually a highlighting for swift.

It works well for gravity currently though, and we can change it as
needed.