### PR TITLE
Windows build - Fix file read/write and windows includes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,12 @@ SRC = $(wildcard $(COMPILER_DIR)*.c) \
 INCLUDE = -I$(COMPILER_DIR) -I$(RUNTIME_DIR) -I$(SHARED_DIR) -I$(UTILS_DIR)
 CFLAGS = $(INCLUDE) -O2 -std=gnu99
 OBJ = $(SRC:.c=.o)
-LDFLAGS = -lm
+
+ifeq ($(OS),Windows_NT)
+	LDFLAGS = -lm -lShlwapi
+else
+	LDFLAGS = -lm
+endif
 
 all: unittest gravity
 

--- a/src/utils/gravity_utils.h
+++ b/src/utils/gravity_utils.h
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 
 #if defined(_WIN32)
+#include <windows.h>
 typedef unsigned __int64 nanotime_t;
 #define DIRREF			HANDLE
 #else


### PR DESCRIPTION
Building with:
`mingw32-make CC=gcc`

This will successfully build both `gravity.exe` and `unittest.exe`.
I have tested gravity.exe with examples on https://marcobambini.github.io/gravity/syntax.html and it works OK. Linux build is unbroken (tested on Windows 10 bash).

This has uncovered a bug with the `unittest` project where there is a problem with `directory_read` and `FindNextFile` on win32 and is not finding files, but thats for another issue/PR.