### PR TITLE
Remove warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SRC = $(wildcard $(COMPILER_DIR)*.c) \
       $(wildcard $(UTILS_DIR)/*.c)
 
 INCLUDE = -I$(COMPILER_DIR) -I$(RUNTIME_DIR) -I$(SHARED_DIR) -I$(UTILS_DIR)
-CFLAGS = $(INCLUDE) -O2 -std=gnu99
+CFLAGS = $(INCLUDE) -O2 -std=gnu99 -fgnu89-inline
 OBJ = $(SRC:.c=.o)
 
 ifeq ($(OS),Windows_NT)

--- a/src/compiler/gravity_ast.c
+++ b/src/compiler/gravity_ast.c
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 CreoLabs. All rights reserved.
 //
 
+#include <inttypes.h>
 #include "gravity_ast.h"
 #include "gravity_utils.h"
 #include "gravity_visitor.h"
@@ -344,7 +345,7 @@ void gnode_literal_dump (gnode_literal_expr_t *node, char *buffer, int buffersiz
 	switch (node->type) {
 		case LITERAL_STRING: snprintf(buffer, buffersize, "STRING: %.*s", node->len, node->value.str); break;
 		case LITERAL_FLOAT: snprintf(buffer, buffersize, "FLOAT: %.2f", node->value.d); break;
-		case LITERAL_INT: snprintf(buffer, buffersize, "INT: %lld", (int64_t)node->value.n64); break;
+		case LITERAL_INT: snprintf(buffer, buffersize, "INT: %" PRId64, (int64_t)node->value.n64); break;
 		case LITERAL_BOOL: snprintf(buffer, buffersize, "BOOL: %d", (int32_t)node->value.n64); break;
 		default: assert(0); // should never reach this point
 	}

--- a/src/compiler/gravity_codegen.c
+++ b/src/compiler/gravity_codegen.c
@@ -737,7 +737,7 @@ static void process_getter_setter (gvisitor_t *self, gnode_var_t *p, gravity_cla
 		if (!node) continue;
 		
 		// create gravity function
-		uint16_t nparams = (uint16_t)(node->params) ? marray_size(*node->params) : 0;
+		uint16_t nparams = (node->params) ? (uint16_t)marray_size(*node->params) : 0;
 		f2[i] = gravity_function_new(NULL, NULL, nparams, node->nlocals, 0, ircode_create(node->nlocals+nparams));
 		
 		// process inner block
@@ -765,7 +765,7 @@ static void visit_function_decl (gvisitor_t *self, gnode_function_decl_t *node) 
 	bool is_class_ctx = OBJECT_ISA_CLASS(context_object);
 	
 	// create new function object
-	uint16_t nparams = (uint16_t)(node->params) ? marray_size(*node->params) : 0;
+	uint16_t nparams = (node->params) ? (uint16_t)marray_size(*node->params) : 0;
 	gravity_function_t *f = gravity_function_new((is_class_ctx) ? NULL : GET_VM(), node->identifier,
 												 nparams, node->nlocals, 0, (void *)ircode_create(node->nlocals+nparams));
 	

--- a/src/compiler/gravity_ircode.c
+++ b/src/compiler/gravity_ircode.c
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 CreoLabs. All rights reserved.
 //
 
+#include <inttypes.h>
 #include "gravity_ircode.h"
 #include "gravity_value.h"
 #include "gravity_debug.h"
@@ -313,7 +314,7 @@ void ircode_dump  (void *_code) {
 			case 2: {
 				if (op == LOADI) {
 					if (inst->tag == DOUBLE_TAG) printf("%05d\t%s %d %.2f\n", line, opcode_name(op), p1, inst->d);
-					else printf("%05d\t%s %d %lld\n", line, opcode_name(op), p1, inst->n);
+					else printf("%05d\t%s %d %" PRId64 "\n", line, opcode_name(op), p1, inst->n);
 				} else if (op == LOADK) {
 					if (p2 < CPOOL_INDEX_MAX) printf("%05d\t%s %d %d\n", line, opcode_name(op), p1, p2);
 					else printf("%05d\t%s %d %s\n", line, opcode_name(op), p1, opcode_constname(p2));

--- a/src/runtime/gravity_core.c
+++ b/src/runtime/gravity_core.c
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 CreoLabs. All rights reserved.
 //
 
+#include <inttypes.h>
 #include <math.h>
 #include "gravity_core.h"
 #include "gravity_hash.h"
@@ -302,7 +303,7 @@ inline gravity_value_t convert_value2string (gravity_vm *vm, gravity_value_t v) 
 	if (VALUE_ISA_INT(v)) {
 		char buffer[512];
 		#if GRAVITY_ENABLE_INT64
-		snprintf(buffer, sizeof(buffer), "%lld", v.n);
+		snprintf(buffer, sizeof(buffer), "%" PRId64, v.n);
 		#else
 		snprintf(buffer, sizeof(buffer), "%d", v.n);
 		#endif

--- a/src/shared/gravity_hash.c
+++ b/src/shared/gravity_hash.c
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 CreoLabs. All rights reserved.
 //
 
+#include <inttypes.h>
 #include "gravity_hash.h"
 
 #if GRAVITYHASH_ENABLE_STATS
@@ -315,7 +316,7 @@ uint32_t gravity_hash_compute_buffer (const char *key, uint32_t len) {
 
 uint32_t gravity_hash_compute_int (gravity_int_t n) {
 	char buffer[24];
-	snprintf(buffer, sizeof(buffer), "%lld", n);
+	snprintf(buffer, sizeof(buffer), "%" PRId64, n);
 	return murmur3_32(buffer, (uint32_t)strlen(buffer), HASH_SEED_VALUE);
 }
 

--- a/src/shared/gravity_value.c
+++ b/src/shared/gravity_value.c
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 CreoLabs. All rights reserved.
 //
 
+#include <inttypes.h>
 #include "gravity_hash.h"
 #include "gravity_core.h"
 #include "gravity_value.h"
@@ -549,7 +550,7 @@ static void gravity_function_cpool_dump (gravity_function_t *f) {
 		if (v.isa == gravity_class_bool) {
 			printf("%05zu\tBOOL: %d\n", i, (v.n == 0) ? 0 : 1);
 		} else if (v.isa == gravity_class_int) {
-			printf("%05zu\tINT: %lld\n", i, (int64_t)v.n);
+			printf("%05zu\tINT: %" PRId64 "\n", i, (int64_t)v.n);
 		} else if (v.isa == gravity_class_float) {
 			printf("%05zu\tFLOAT: %f\n", i, (double)v.f);
 		} else if (v.isa == gravity_class_function) {
@@ -1615,7 +1616,7 @@ void gravity_value_dump (gravity_value_t v, char *buffer, uint16_t len) {
 		value = buffer;
 	} else if (v.isa == gravity_class_int) {
 		type = "INT";
-		snprintf(buffer, len, "(%s) %lld", type, v.n);
+		snprintf(buffer, len, "(%s) %" PRId64, type, v.n);
 		value = buffer;
 	} else if (v.isa == gravity_class_float) {
 		type = "FLOAT";
@@ -1656,7 +1657,7 @@ void gravity_value_dump (gravity_value_t v, char *buffer, uint16_t len) {
 	} else if (v.isa == gravity_class_range) {
 		type = "RANGE";
 		gravity_range_t *r = VALUE_AS_RANGE(v);
-		snprintf(buffer, len, "(%s) from %lld to %lld", type, r->from, r->to);
+		snprintf(buffer, len, "(%s) from %" PRId64 " to %" PRId64, type, r->from, r->to);
 		value = buffer;
 	} else if (v.isa == gravity_class_object) {
 		type = "OBJECT";

--- a/src/utils/gravity_json.c
+++ b/src/utils/gravity_json.c
@@ -31,6 +31,7 @@
 #include "gravity_utils.h"
 #include "gravity_memory.h"
 
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -245,7 +246,7 @@ void json_add_cstring (json_t *json, const char *key, const char *value) {
 
 void json_add_int (json_t *json, const char *key, int64_t value) {
 	char buffer[512];
-	size_t len = snprintf(buffer, sizeof(buffer), "%lld", value);
+	size_t len = snprintf(buffer, sizeof(buffer), "%" PRId64, value);
 	
 	if (key) {
 		json_write_raw (json, key, strlen(key), true, true);


### PR DESCRIPTION
This should remove all the warnings that get produced from make.

All tests pass for me with this change.

I forgot to disable the part of my text editor that removes trailing whitespace, so there are a lot of those changes. If you would prefer to not have the whitespace removed in these commits, let me know and I will go back through and just make the actual changes (since the whitespace changes account for a lot of modifications)

The `-fgnu89-inline` flag in the Makefile tells GCC to use the traditional GNU semantics for inline functions when in C99 mode, thus eliminating the warnings produced by the inline functions