### PR TITLE
Fix indentation in syntax.html

### DIFF
--- a/docs/syntax.html
+++ b/docs/syntax.html
@@ -161,12 +161,12 @@
 	// block scope can be nested and
 	// can hide other local variables
 	func f3() {
-	    var a = 10;
-	    if (a > 0) {
-		  var a = 20;
-	    }
-	// 10 is returned here
-	return a;
+		var a = 10;
+		if (a > 0) {
+			var a = 20;
+		}
+		// 10 is returned here
+		return a;
 	}
 			</code></pre>
 			


### PR DESCRIPTION
It seems there are some indentation errors at "Gravity: Syntax" > "Blocks and Scope"
see: https://marcobambini.github.io/gravity/syntax.html
1 tab is used in other code blocks.