### PR TITLE
Making tab-size smaller in highlighted code

### DIFF
--- a/docs/stylesheets/styles.css
+++ b/docs/stylesheets/styles.css
@@ -21,6 +21,11 @@ pre {
 	background-color: transparent;
 }
 
+/* Highlight tab size */
+.hljs {
+	tab-size: 2;
+}
+
 /***** NAVBAR *****/
 .navbar-brand {
     padding-top: 7px;


### PR DESCRIPTION
Tabsize is currently way too wide, making code examples look kinda odd. This one-liner PR fix that.

Example:
![befaf](https://cloud.githubusercontent.com/assets/1953194/23827284/c5390fd8-068e-11e7-9821-cc0cced4cbd7.png)
