### PR TITLE
Fixed a typo in lists.html for the push/pop section

### DIFF
--- a/docs/lists.html
+++ b/docs/lists.html
@@ -118,7 +118,7 @@
 			</code></pre>
 			
 			<h4 class="section-h4">List as a stack</h4>
-			<p>The List class implements the push/pop methods as a convenient way to threat a list as a stack:</p> 
+			<p>The List class implements the push/pop methods as a convenient way to treat a list as a stack:</p> 
 			<pre><code class="swift">
 	var list = [10,20,30,40,50];
 	list.push(100);		// add 100 to the list


### PR DESCRIPTION
I noticed that "treat" was spelled wrong in the lists.html doc.