### PR TITLE
Resolves a compilation warning regard %lld

### DIFF
--- a/src/compiler/gravity_ircode.c
+++ b/src/compiler/gravity_ircode.c
@@ -287,7 +287,7 @@ void ircode_dump  (void *_code) {
 			case 2: {
 				if (op == LOADI) {
 					if (inst->tag == DOUBLE_TAG) printf("%05d\t%s %d %.2f\n", line, opcode_name(op), p1, inst->d);
-					else printf("%05d\t%s %d %lld\n", line, opcode_name(op), p1, inst->n);
+					else printf("%05d\t%s %d %ld\n", line, opcode_name(op), p1, inst->n);
 				} else if (op == LOADK) {
 					if (p2 < CPOOL_INDEX_MAX) printf("%05d\t%s %d %d\n", line, opcode_name(op), p1, p2);
 					else printf("%05d\t%s %d %s\n", line, opcode_name(op), p1, opcode_constname(p2));


### PR DESCRIPTION
```bash
src/compiler/gravity_ircode.c: In function ‘ircode_dump’:
src/compiler/gravity_ircode.c:290:18: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 5 has type ‘int64_t {aka long int}’ [-Wformat=]
```

Went to rebuild gravity with the latest changes and received this warning.

Looks to be the same as one of the warnings I had earlier: https://github.com/marcobambini/gravity/pull/39#issuecomment-284965685