### PR TITLE
Resolved a compilation warning regardding %lld/ %ld

### DIFF
--- a/src/compiler/gravity_ircode.c
+++ b/src/compiler/gravity_ircode.c
@@ -287,7 +287,7 @@ void ircode_dump  (void *_code) {
 			case 2: {
 				if (op == LOADI) {
 					if (inst->tag == DOUBLE_TAG) printf("%05d\t%s %d %.2f\n", line, opcode_name(op), p1, inst->d);
-					else printf("%05d\t%s %d %lld\n", line, opcode_name(op), p1, inst->n);
+					else printf("%05d\t%s %d %ld\n", line, opcode_name(op), p1, inst->n);
 				} else if (op == LOADK) {
 					if (p2 < CPOOL_INDEX_MAX) printf("%05d\t%s %d %d\n", line, opcode_name(op), p1, p2);
 					else printf("%05d\t%s %d %s\n", line, opcode_name(op), p1, opcode_constname(p2));


### PR DESCRIPTION
I got one of these warnings again when I compile gravity.