### PR TITLE
Have the unittests return an error of a test fails

### DIFF
--- a/src/cli/unittest.c
+++ b/src/cli/unittest.c
@@ -181,7 +181,7 @@ int main (int argc, const char* argv[]) {
 	
 	if (argc != 2) {
 		printf("Usage: unittest /path/to/unitest/\n");
-		return 0;
+		return 1;
 	}
 	
 	// print console header
@@ -208,5 +208,9 @@ int main (int argc, const char* argv[]) {
 	printf("==============================================\n");
 	printf("\n");
 	
+	// If we have 1 or more failures, return an error.
+	if (data.nfailure != 0) {
+		return 1;
+	}
 	return 0;
 }


### PR DESCRIPTION
This will help with certain automations that look for error codes to
determine what happens.

For example, running `git bisect` or an interactive rebase using exec,
or any other type of automated testing or building that users use.

With the new return codes commands like bisect will understand that the test has failed