### PR TITLE
Added a String.substr() method

### DIFF
--- a/docs/types.html
+++ b/docs/types.html
@@ -138,6 +138,10 @@
 	// and retrieve those characters
 	n = a[6]                // n is now "W"
 	n = a[-7]               // n is now "o"
+	n = a[0...4]            // n is now "Hello"
+	n = a[-5...-1]          // n is now "World"
+	n = a[-5...10]          // n is now "World"
+	n = a[-1...-5]          // n is now "dlroW"
 			</code></pre>
 			
 			<h4 class="section-h4">Bool</h4>

--- a/test/string/loadat.gravity
+++ b/test/string/loadat.gravity
@@ -6,8 +6,11 @@
 
 func main () {
 	var s = "Hello World"
-	if (s[6] == s[-5] and s[6] == "W") {
-		return true
-	}
-	return false
+	var ret = s[6] == s[-5] and s[6] == "W"
+
+	ret = ret and s[-1...0] == "dlroW olleH"
+	ret = ret and s[0...4] == "Hello"
+	ret = ret and s[-5...-1] == "World"
+
+	return ret
 }

--- a/test/string/loadat_error.gravity
+++ b/test/string/loadat_error.gravity
@@ -5,5 +5,6 @@
 
 func main () {
 	var s = "Hello World"
-	return s[11]
+	// out of bounds
+	return s[0...11]
 }


### PR DESCRIPTION
added a substring method that takes either 1 or 2 arguments.

if one argument is provided, it takes the substring defined by that index of the string, to the end of the string, otherwise it is the string defined by two given indices.

For example:

```swift
var str = "Hello, World!"
return str.substr(7, 11) // "World"... or str.substr(7, -2)
```

Not sure if someone else has a better name for it, but I am open to suggestions if substr() is not appealing.

It also seems that some languages specify the ending index of the character after the last character you want, while this stops the substring at the character you specify...

For instance, in JS that substring command I gave above would return "Worl" instead of "World".

I have also seen some languages take the substring length as the second argument and that is a possibility as well, instead of what this implementation gives.

Perhaps this needs further discussion on if the name needs to be changed, or we want to change the meaning of the 2nd index