### PR TITLE
fix null ptr deref ((gnode_base_t *)top)->base.tag

### DIFF
--- a/src/compiler/gravity_semacheck2.c
+++ b/src/compiler/gravity_semacheck2.c
@@ -807,7 +807,9 @@ static void visit_enum_decl (gvisitor_t *self, gnode_enum_decl_t *node) {
 	
 	// check if optional access and storage specifiers make sense in current context
 	gnode_t *top = TOP_DECLARATION();
-	check_access_storage_specifiers(self, (gnode_t *)node, NODE_TAG(top), node->access, node->storage);
+	if(top) {
+	    check_access_storage_specifiers(self, (gnode_t *)node, NODE_TAG(top), node->access, node->storage);
+	}
 }
 
 static void visit_class_decl (gvisitor_t *self, gnode_class_decl_t *node) {


### PR DESCRIPTION
Was curious if this is a real null pointer dereference issue?

CodeAi, an automated repair tool being developed at Qbit logic, suggested an if-guard as a fix.

The possible dereference happened in gravity_semacheck2.c on line 810. It looks like `top` can be a null pointer from the expansion of the macro `TOP_DECLARATION()`:
```
(((((((semacheck_t *)self->data)->declarations)
        ? ((*((semacheck_t *)self->data)->declarations).n)
        : 0) -
   1) >= 0 &&
  (((((semacheck_t *)self->data)->declarations)
        ? ((*((semacheck_t *)self->data)->declarations).n)
        : 0) -
   1) < ((*((semacheck_t *)self->data)->declarations).n))
     ? ((*((semacheck_t *)self->data)->declarations)
            .p[((((((semacheck_t *)self->data)->declarations)
                      ? ((*((semacheck_t *)self->data)->declarations).n)
                      : 0) -
                 1))])
     : ((void *)0))
```

Then it is dereferenced on the next line (`NODE_TAG(top)`), which expands to : `((gnode_base_t *)top)->base.tag`

Thanks so much.