### PR TITLE
Resolved a compilation warning about %lld

### DIFF
--- a/src/runtime/gravity_core.c
+++ b/src/runtime/gravity_core.c
@@ -965,7 +965,7 @@ static bool list_join (gravity_vm *vm, gravity_value_t *args, uint16_t nargs, ui
             // sanity check
             if (to_alloc > MAX_MEMORY_BLOCK) {
                 mem_free(_buffer);
-                RETURN_ERROR("Maximum memory block size reached (max %d, requested %lld).", MAX_MEMORY_BLOCK, to_alloc);
+                RETURN_ERROR("Maximum memory block size reached (max %d, requested %ld).", MAX_MEMORY_BLOCK, to_alloc);
             }
             
 			_buffer = mem_realloc(_buffer, (uint32_t)to_alloc);


### PR DESCRIPTION
I was getting a compilation warning with this particular line of code. Changing to `%ld` from `%lld` removes the warning for me.