### PR TITLE
Built in sort and reverse

### DIFF
--- a/src/runtime/gravity_core.c
+++ b/src/runtime/gravity_core.c
@@ -928,6 +928,35 @@ static bool list_loop (gravity_vm *vm, gravity_value_t *args, uint16_t nargs, ui
 	RETURN_VALUE(VALUE_FROM_INT(t2-t1), rindex);
 }
 
+static bool list_reverse (gravity_vm *vm, gravity_value_t *args, uint16_t nargs, uint32_t rindex) {
+  if (nargs > 1) RETURN_ERROR("Incorrect number of arguments.");
+  gravity_value_t value = GET_VALUE(0);							// self parameter
+  gravity_list_t *list = VALUE_AS_LIST(value);
+  register uint32_t count = (uint32_t)marray_size(list->array);
+  register gravity_int_t i = 0;
+  while (i < count/2) {
+    gravity_value_t tmp = marray_get(list->array, count-i-1);
+    marray_set(list->array, count-i-1,  marray_get(list->array, i));
+    marray_set(list->array, i,  tmp);
+    i++;
+  }
+  RETURN_VALUE(VALUE_FROM_OBJECT(list), rindex);
+}
+
+static bool list_reversed (gravity_vm *vm, gravity_value_t *args, uint16_t nargs, uint32_t rindex) {
+  if (nargs > 1) RETURN_ERROR("Incorrect number of arguments.");
+  gravity_value_t value = GET_VALUE(0);							// self parameter
+  gravity_list_t *list = VALUE_AS_LIST(value);
+  gravity_list_t *newlist = gravity_list_new(vm, list->array.n);
+  register uint32_t count = (uint32_t)marray_size(list->array);
+  register gravity_int_t i = 0;
+  while (i < count) {
+    marray_push(gravity_value_t, newlist->array, marray_get(list->array, count-i-1));
+    i++;
+  }
+  RETURN_VALUE(VALUE_FROM_OBJECT(newlist), rindex);
+}
+
 static bool list_join (gravity_vm *vm, gravity_value_t *args, uint16_t nargs, uint32_t rindex) {
 	gravity_list_t *list = VALUE_AS_LIST(GET_VALUE(0));
 	const char *sep = NULL;
@@ -2482,6 +2511,8 @@ static void gravity_core_init (void) {
 	gravity_class_bind(gravity_class_list, "contains", NEW_CLOSURE_VALUE(list_contains));
     gravity_class_bind(gravity_class_list, "remove", NEW_CLOSURE_VALUE(list_remove));
     gravity_class_bind(gravity_class_list, "indexOf", NEW_CLOSURE_VALUE(list_indexOf));
+    gravity_class_bind(gravity_class_list, "reverse", NEW_CLOSURE_VALUE(list_reverse));
+    gravity_class_bind(gravity_class_list, "reversed", NEW_CLOSURE_VALUE(list_reversed));
     // Meta
     gravity_class_t *list_meta = gravity_class_get_meta(gravity_class_list);
     gravity_class_bind(list_meta, GRAVITY_INTERNAL_EXEC_NAME, NEW_CLOSURE_VALUE(list_exec));

--- a/src/runtime/gravity_core.c
+++ b/src/runtime/gravity_core.c
@@ -932,8 +932,8 @@ static bool list_reverse (gravity_vm *vm, gravity_value_t *args, uint16_t nargs,
   if (nargs > 1) RETURN_ERROR("Incorrect number of arguments.");
   gravity_value_t value = GET_VALUE(0);							// self parameter
   gravity_list_t *list = VALUE_AS_LIST(value);
-  register uint32_t count = (uint32_t)marray_size(list->array);
-  register gravity_int_t i = 0;
+  uint32_t count = (uint32_t)marray_size(list->array);
+  gravity_int_t i = 0;
   while (i < count/2) {
     gravity_value_t tmp = marray_get(list->array, count-i-1);
     marray_set(list->array, count-i-1,  marray_get(list->array, i));
@@ -948,8 +948,8 @@ static bool list_reversed (gravity_vm *vm, gravity_value_t *args, uint16_t nargs
   gravity_value_t value = GET_VALUE(0);							// self parameter
   gravity_list_t *list = VALUE_AS_LIST(value);
   gravity_list_t *newlist = gravity_list_new(vm, list->array.n);
-  register uint32_t count = (uint32_t)marray_size(list->array);
-  register gravity_int_t i = 0;
+  uint32_t count = (uint32_t)marray_size(list->array);
+  gravity_int_t i = 0;
   while (i < count) {
     marray_push(gravity_value_t, newlist->array, marray_get(list->array, count-i-1));
     i++;

--- a/test/unittest/list_reverse.gravity
+++ b/test/unittest/list_reverse.gravity
@@ -1,0 +1,10 @@
+#unittest {
+    name: "List reverse.";
+    result: "[4,2,1,6,4]";
+};
+
+func main() {
+  var list = [4, 6, 1, 2, 4]
+  list.reverse()
+  return list.String()
+}

--- a/test/unittest/list_reversed.gravity
+++ b/test/unittest/list_reversed.gravity
@@ -1,0 +1,10 @@
+#unittest {
+    name: "List reversed.";
+    result: "[4,6,1,2,4]";
+};
+
+func main() {
+  var list = [4, 6, 1, 2, 4]
+  var reversed_list = list.reversed() //[4,2,1,6,4], list remains unmodified
+  return list.String()
+}

--- a/test/unittest/list_sort.gravity
+++ b/test/unittest/list_sort.gravity
@@ -1,0 +1,14 @@
+#unittest {
+    name: "List sort.";
+    result: "[1,2,4,4,6]";
+};
+
+func main() {
+  func predicate(a, b) {
+    return a > b
+  }
+  
+  var list = [4, 6, 1, 2, 4]
+  list.sort(predicate)
+  return list.String()
+}

--- a/test/unittest/list_sorted.gravity
+++ b/test/unittest/list_sorted.gravity
@@ -1,0 +1,14 @@
+#unittest {
+    name: "List sorted.";
+    result: "[4,6,1,2,4]";
+};
+
+func main() {
+  func predicate(a, b) {
+    return a > b
+  }
+
+  var list = [4, 6, 1, 2, 4]
+  var sorted_list = list.sorted(predicate) //[1,2,4,4,6], list remains unmodified
+  return list.String()
+}


### PR DESCRIPTION
This idea was originally floated in issue #104. Four list class methods have been added here--reverse(), reversed(), sort(), and sorted(). Sort() and sorted() both take a "predicate" argument, which is a function (closure) that takes two arguments and returns a "truthy" value. The sort functions use an implementation of quicksort, though Timsort was also suggested as a possibility.

Unittests have been added to make sure that reverse() and sort() modify the original list, while reversed() and sorted() return a new list and leave the original unmodified.

I'd appreciate any feedback!