### PR TITLE
Reduce CC = to CC ?= in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OPT_DIR = src/optionals/
 UNITTEST_SRC = src/cli/unittest.c
 GRAVITY_SRC = src/cli/gravity.c
 
-CC = gcc
+CC ?= gcc
 SRC = $(wildcard $(COMPILER_DIR)*.c) \
       $(wildcard $(RUNTIME_DIR)/*.c) \
       $(wildcard $(SHARED_DIR)/*.c) \


### PR DESCRIPTION
Some packaging tools (e.g. OpenBSD ports) predefine CC, since our default compiler is clang, not gcc. This allows systems that don't have CC defined to use gcc, and those that do use their preselected compiler. As-is, your invocation of CC=gcc clobbers any predefined CC, and this breaks the OpenBSD ports build without additional patching on our end.