### PR TITLE
Added unittest and !test/unittest to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,8 @@ paket-files/
 *.x86_64
 *.hex
 gravity
+unittest
+!test/unittest
 
 # Debug files
 *.dSYM/


### PR DESCRIPTION
Without those lines, the unittest executable shows up in a git status as
untracked as opposed to be ignored.

These lines used to be in the gitignore but were removed in d7b73ef19dc351f06b3dbd5960766728e38a1fd3#diff-a084b794bc0759e7a6b77810e01874f2 though I am not sure why. If there was a reason for it can someone let me know.