### PR TITLE
Supress division by zero warning in GCC.

### DIFF
--- a/src/runtime/gravity_vm.c
+++ b/src/runtime/gravity_vm.c
@@ -899,10 +899,19 @@ static bool gravity_vm_exec (gravity_vm *vm) {
 
                 // check fast math operation first  (only in case of int and float)
                 // a special check macro is added in order to check for divide by zero cases
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wdivision-by-zero"
+                #if defined(__clang__)
+                    #pragma clang diagnostic push
+                    #pragma clang diagnostic ignored "-Wdivision-by-zero"
+                #elif defined(__GNUC__)
+                    #pragma GCC diagnostic push
+                    #pragma GCC diagnostic ignored "-Wdiv-by-zero"
+                #endif
                 CHECK_FAST_BINARY_MATH(r1, r2, r3, v2, v3, /, CHECK_ZERO(v3));
-                 #pragma clang diagnostic pop
+                #if defined(__clang__)
+                    #pragma clang diagnostic pop
+                #elif defined(__GNUC__)
+                    #pragma GCC diagnostic pop
+                #endif
 
                 // prepare function call for binary operation
                 PREPARE_FUNC_CALL2(closure, v2, v3, GRAVITY_DIV_INDEX, rwin);


### PR DESCRIPTION
It only took Clang into consideration.