### PR TITLE
Function returns address of local variable fix.

### DIFF
--- a/src/cli/gravity.c
+++ b/src/cli/gravity.c
@@ -170,9 +170,13 @@ static const char *unittest_read (const char *path, size_t *size, uint32_t *file
 static void unittest_scan (const char *folder_path, unittest_data *data) {
     DIRREF dir = directory_init(folder_path);
     if (!dir) return;
-    
+#ifdef WIN32
+    char outbuffer[MAX_PATH];
+#else
+    char * outbuffer = NULL;
+#endif
     const char *target_file;
-    while ((target_file = directory_read(dir))) {
+    while ((target_file = directory_read(dir, outbuffer))) {
         
         #ifdef WIN32
         const char winbuffer[MAX_PATH];

--- a/src/utils/gravity_utils.c
+++ b/src/utils/gravity_utils.c
@@ -261,7 +261,7 @@ DIRREF directory_init (const char *dirpath) {
 	#endif
 }
 
-const char *directory_read (DIRREF ref) {
+const char *directory_read (DIRREF ref, char *out) {
 	if (ref == NULL) return NULL;
 	
 	while (1) {
@@ -275,7 +275,9 @@ const char *directory_read (DIRREF ref) {
 		if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) continue;
 		if (findData.cFileName[0] == '\0') continue;
 		if (findData.cFileName[0] == '.') continue;
-		return (const char*)findData.cFileName;
+		// cFileName from WIN32_FIND_DATAA is a fixed size array, and findData is local
+		// This line of code is under the assumption that `out` is at least MAX_PATH in size!
+		return !out ? NULL : memcpy(out, findData.cFileName, sizeof(findData.cFileName));
 		#else
 		struct dirent *d;
 		if ((d = readdir(ref)) == NULL) {

--- a/src/utils/gravity_utils.h
+++ b/src/utils/gravity_utils.h
@@ -40,7 +40,8 @@ bool        file_write (const char *path, const char *buffer, size_t len);
 // DIRECTORY
 bool        is_directory (const char *path);
 DIRREF      directory_init (const char *path);
-const char  *directory_read (DIRREF ref);
+// On Windows, you are expected to provied an output buffer of at least MAX_PATH in length
+const char  *directory_read (DIRREF ref, char *out);
 
 // STRING
 int         string_nocasencmp (const char *s1, const char *s2, size_t n);


### PR DESCRIPTION
On Windows, `directory_read()` utility returns the address of a fixed size array from a local structure. The fix is quite hackish but does the job.