### PR TITLE
Cast pointer to uintptr_t instead of unsigned long.

### DIFF
--- a/src/utils/gravity_json.c
+++ b/src/utils/gravity_json.c
@@ -433,7 +433,7 @@ static int new_value (json_state * state,
             values_size = sizeof (*value->u.object.values) * value->u.object.length;
 
             if (! (value->u.object.values = (json_object_entry *) json_alloc
-                  (state, values_size + ((unsigned long) value->u.object.values), 0)) )
+                  (state, values_size + ((uintptr_t) value->u.object.values), 0)) )
             {
                return 0;
             }


### PR DESCRIPTION
Because long could be 32bit on other platforms (_ie. Windows_) regardless of architecture.

Although I don't quite understand that cast or it's purpose (_didn't look much into it either_). It looks quite awkward at a glance. Perhaps I should've looked deeper into the implementation.

Which means if that was the intended behavior. Then I apologize and please ignore this PR.