### PR TITLE
GRAVITY_USE_HIDDEN_INITIALIZERS to hide public facing designated initializers when using C++

### DIFF
--- a/src/shared/gravity_config.h
+++ b/src/shared/gravity_config.h
@@ -35,4 +35,12 @@ typedef int         mode_t;
 #include <unistd.h>
 #endif
 
+// check if the compiler supports designated initializers when using c++
+#ifndef GRAVITY_USE_HIDDEN_INITIALIZERS
+    #if __cplusplus && (__cplusplus < 202002L)
+        // C++ di requires C++20
+        #define GRAVITY_USE_HIDDEN_INITIALIZERS 1
+    #endif // __cplusplus
+#endif // GRAVITY_USE_HIDDEN_INITIALIZERS
+
 #endif // __GRAVITY_CONFIG__

--- a/src/shared/gravity_macros.h
+++ b/src/shared/gravity_macros.h
@@ -9,6 +9,8 @@
 #ifndef __GRAVITY_MACROS__
 #define __GRAVITY_MACROS__
 
+#include "gravity_config.h"
+
 #define AUTOLENGTH                          UINT32_MAX
 
 // MARK: -
@@ -36,6 +38,20 @@
 #define VALUE_AS_BOOL(x)                    ((x).n)
 
 // MARK: -
+#if GRAVITY_USE_HIDDEN_INITIALIZERS
+#define VALUE_FROM_ERROR(msg)               (gravity_value_from_error(msg))
+#define VALUE_NOT_VALID                     VALUE_FROM_ERROR(NULL)
+#define VALUE_FROM_OBJECT(obj)              (gravity_value_from_object(obj))
+#define VALUE_FROM_STRING(_vm,_s,_len)      (gravity_string_to_value(_vm, _s, _len))
+#define VALUE_FROM_CSTRING(_vm,_s)          (gravity_string_to_value(_vm, _s, AUTOLENGTH))
+#define VALUE_FROM_INT(x)                   (gravity_value_from_int(x))
+#define VALUE_FROM_FLOAT(x)                 (gravity_value_from_float(x))
+#define VALUE_FROM_NULL                     (gravity_value_from_null())
+#define VALUE_FROM_UNDEFINED                (gravity_value_from_undefined())
+#define VALUE_FROM_BOOL(x)                  (gravity_value_from_bool(x))
+#define VALUE_FROM_FALSE                    VALUE_FROM_BOOL(0)
+#define VALUE_FROM_TRUE                     VALUE_FROM_BOOL(1)
+#else
 #define VALUE_FROM_ERROR(msg)               ((gravity_value_t){.isa = NULL, .p = ((gravity_object_t *)msg)})
 #define VALUE_NOT_VALID                     VALUE_FROM_ERROR(NULL)
 #define VALUE_FROM_OBJECT(obj)              ((gravity_value_t){.isa = ((gravity_object_t *)(obj)->isa), .p = (gravity_object_t *)(obj)})
@@ -48,9 +64,12 @@
 #define VALUE_FROM_BOOL(x)                  ((gravity_value_t){.isa = gravity_class_bool, .n = (x)})
 #define VALUE_FROM_FALSE                    VALUE_FROM_BOOL(0)
 #define VALUE_FROM_TRUE                     VALUE_FROM_BOOL(1)
+#endif // GRAVITY_USE_HIDDEN_INITIALIZERS
+
 #define STATICVALUE_FROM_STRING(_v,_s,_l)   gravity_string_t __temp = {.isa = gravity_class_string, .s = (char *)_s, .len = (uint32_t)_l, }; \
                                             __temp.hash = gravity_hash_compute_buffer(__temp.s, __temp.len); \
                                             gravity_value_t _v = {.isa = gravity_class_string, .p = (gravity_object_t *)&__temp };
+
 // MARK: -
 #define VALUE_ISA_FUNCTION(v)               (v.isa == gravity_class_function)
 #define VALUE_ISA_INSTANCE(v)               (v.isa == gravity_class_instance)

--- a/src/shared/gravity_value.c
+++ b/src/shared/gravity_value.c
@@ -2438,3 +2438,31 @@ uint32_t gravity_string_size (gravity_vm *vm, gravity_string_t *string) {
 void gravity_string_blacken (gravity_vm *vm, gravity_string_t *string) {
     gravity_vm_memupdate(vm, gravity_string_size(vm, string));
 }
+
+inline gravity_value_t gravity_value_from_error(const char* msg) {
+    return ((gravity_value_t){.isa = NULL, .p = ((gravity_object_t *)msg)});
+}
+
+inline gravity_value_t gravity_value_from_object(gravity_object_t *obj) {
+    return ((gravity_value_t){.isa = ((gravity_object_t *)(obj)->isa), .p = (gravity_object_t *)(obj)});
+}
+
+inline gravity_value_t gravity_value_from_int(gravity_int_t n) {
+    return ((gravity_value_t){.isa = gravity_class_int, .n = (n)});
+}
+
+inline gravity_value_t gravity_value_from_float(gravity_float_t f) {
+    return ((gravity_value_t){.isa = gravity_class_float, .f = (f)});
+}
+
+inline gravity_value_t gravity_value_from_null() {
+    return ((gravity_value_t){.isa = gravity_class_null, .n = 0});
+}
+
+inline gravity_value_t gravity_value_from_undefined() {
+    return ((gravity_value_t){.isa = gravity_class_null, .n = 1});
+}
+
+inline gravity_value_t gravity_value_from_bool(bool b) {
+    return ((gravity_value_t){.isa = gravity_class_bool, .n = (b)});
+}

--- a/src/shared/gravity_value.c
+++ b/src/shared/gravity_value.c
@@ -2443,8 +2443,8 @@ inline gravity_value_t gravity_value_from_error(const char* msg) {
     return ((gravity_value_t){.isa = NULL, .p = ((gravity_object_t *)msg)});
 }
 
-inline gravity_value_t gravity_value_from_object(gravity_object_t *obj) {
-    return ((gravity_value_t){.isa = ((gravity_object_t *)(obj)->isa), .p = (gravity_object_t *)(obj)});
+inline gravity_value_t gravity_value_from_object(void *obj) {
+    return ((gravity_value_t){.isa = (((gravity_object_t *)(obj))->isa), .p = (gravity_object_t *)(obj)});
 }
 
 inline gravity_value_t gravity_value_from_int(gravity_int_t n) {

--- a/src/shared/gravity_value.h
+++ b/src/shared/gravity_value.h
@@ -520,7 +520,7 @@ GRAVITY_API void                gravity_value_blacken (gravity_vm *vm, gravity_v
 GRAVITY_API uint32_t            gravity_value_size (gravity_vm *vm, gravity_value_t v);
 
 GRAVITY_API gravity_value_t     gravity_value_from_error(const char* msg);
-GRAVITY_API gravity_value_t     gravity_value_from_object(gravity_object_t *obj);
+GRAVITY_API gravity_value_t     gravity_value_from_object(void *obj);
 GRAVITY_API gravity_value_t     gravity_value_from_int(gravity_int_t n);
 GRAVITY_API gravity_value_t     gravity_value_from_float(gravity_float_t f);
 GRAVITY_API gravity_value_t     gravity_value_from_null();

--- a/src/shared/gravity_value.h
+++ b/src/shared/gravity_value.h
@@ -519,6 +519,14 @@ GRAVITY_API const char          *gravity_value_name (gravity_value_t value);
 GRAVITY_API void                gravity_value_blacken (gravity_vm *vm, gravity_value_t v);
 GRAVITY_API uint32_t            gravity_value_size (gravity_vm *vm, gravity_value_t v);
 
+GRAVITY_API gravity_value_t     gravity_value_from_error(const char* msg);
+GRAVITY_API gravity_value_t     gravity_value_from_object(gravity_object_t *obj);
+GRAVITY_API gravity_value_t     gravity_value_from_int(gravity_int_t n);
+GRAVITY_API gravity_value_t     gravity_value_from_float(gravity_float_t f);
+GRAVITY_API gravity_value_t     gravity_value_from_null();
+GRAVITY_API gravity_value_t     gravity_value_from_undefined();
+GRAVITY_API gravity_value_t     gravity_value_from_bool(bool b);
+
 // MARK: - OBJECT -
 GRAVITY_API void                gravity_object_serialize (gravity_object_t *obj, json_t *json);
 GRAVITY_API gravity_object_t    *gravity_object_deserialize (gravity_vm *vm, json_value *entry);


### PR DESCRIPTION
Added `GRAVITY_USE_HIDDEN_INITIALIZERS ` define in gravity_config.h to solve the issue of using Gravity in pre C++20 projects.

Added `gravity_value_from_XXX` functions that implement the `VALUE_FROM_XXX` macros

Reference: #300 Public macros with C++ compatibility