### PR TITLE
Fixed issue in running unit tests on Windows

### DIFF
--- a/src/cli/gravity.c
+++ b/src/cli/gravity.c
@@ -178,12 +178,6 @@ static void unittest_scan (const char *folder_path, unittest_data *data) {
     const char *target_file;
     while ((target_file = directory_read(dir, outbuffer))) {
         
-        #ifdef WIN32
-        char winbuffer[MAX_PATH];
-        WideCharToMultiByte (CP_UTF8, 0, (LPCWSTR)target_file, -1, winbuffer, sizeof(winbuffer), NULL, NULL );
-        target_file = (const char *)winbuffer;
-        #endif
-        
         // if file is a folder then start recursion
         const char *full_path = file_buildpath(target_file, folder_path);
         if (is_directory(full_path)) {


### PR DESCRIPTION
Running `gravity -t` on Windows would fail to find any files to test. Even when the specified path is correct.

`directory_read` uses `FindNextFileA` on Windows which already returns a multi-byte.

`unittest_scan` was attempting to convert a wide char to char.

Tested on Windows with (MSVC, MinGW)