### PR TITLE
added example on inline string formatting

### DIFF
--- a/docs/string.md
+++ b/docs/string.md
@@ -52,3 +52,10 @@ Strings are an immutable sequence of characters. String literals can be surround
 	var str = "momo"
 	str.replace("o", "i") // returns mimi
 ```
+
+Strings can contain inline expressions with backslash and parentheses.
+```swift
+	var amount = 7
+	var fruit = "apples"
+	var n = "You have \(amount) \(fruit)!"  // n is now "You have 7 apples!"
+```


### PR DESCRIPTION
I'm not familiar with swift. However, I discovered the string interpolation in the unit tests.  Added a brief comment about it in the docs.

*Related:* It looks like Gravity scripts and strings are **UTF8**.  I was able to verify when reading a Gravity string from C.

Should there be a comment somewhere indicating they are UTF8?