### PR TITLE
fix some potential null pointer dereference bugs.

### DIFF
--- a/src/compiler/gravity_optimizer.c
+++ b/src/compiler/gravity_optimizer.c
@@ -73,7 +73,7 @@ static void finalize_function (gravity_function_t *f, bool add_debug) {
     // +1 is just a trick so the VM switch loop terminates with an implicit RET0 instruction (RET0 has opcode 0)
     f->ninsts = ninst;
     bytecode = (uint32_t *)mem_alloc(NULL, (ninst+1) * sizeof(uint32_t));
-    if (add_debug) lineno = (uint32_t *)mem_alloc(NULL, (ninst+1) * sizeof(uint32_t));
+    if (add_debug) {lineno = (uint32_t *)mem_alloc(NULL, (ninst+1) * sizeof(uint32_t)); assert(lineno);}
     assert(bytecode);
 
     uint32_t j=0;

--- a/src/compiler/gravity_parser.c
+++ b/src/compiler/gravity_parser.c
@@ -738,6 +738,7 @@ static gnode_t *parse_analyze_literal_string (gravity_parser_t *parser, gtoken_s
 
     // analyze s (of length len) for escaped characters or for interpolations
     char *buffer = mem_alloc(NULL, len+1);
+    if (buffer==NULL) {REPORT_ERROR(token,"Unable to alloc memory for size: 0x%x",len+1); goto return_string}
     uint32_t length = 0;
 
     for (uint32_t i=0; i<len;) {
@@ -840,6 +841,7 @@ static gnode_t *parse_analyze_literal_string (gravity_parser_t *parser, gtoken_s
                     if (!subnode) goto return_string;
 
                     buffer = mem_alloc(NULL, len+1);
+                    if (buffer==NULL) {REPORT_ERROR(token,"Unable to alloc memory for size: 0x%x",len+1); goto return_string}
                     length = 0;
 
                     continue;

--- a/src/optionals/gravity_opt_json.c
+++ b/src/optionals/gravity_opt_json.c
@@ -45,6 +45,7 @@ static bool JSON_stringify (gravity_vm *vm, gravity_value_t *args, uint16_t narg
             RETURN_VALUE(VALUE_FROM_STRING(vm, vbuffer2, (uint32_t)vlen), rindex);
         } else {
             char *vbuffer2 = mem_alloc(NULL, vlen + nchars);
+            assert(vbuffer2);
             vlen = snprintf(vbuffer2, vlen + nchars, "\"%s\"", v);
             RETURN_VALUE(VALUE_FROM_OBJECT(gravity_string_new(vm, vbuffer2, (uint32_t)vlen, 0)), rindex);
         }

--- a/src/shared/gravity_value.c
+++ b/src/shared/gravity_value.c
@@ -191,6 +191,7 @@ gravity_class_t *gravity_class_new_single (gravity_vm *vm, const char *identifie
     c->htable = gravity_hash_create(0, gravity_value_hash, gravity_value_equals, gravity_hash_keyfree, NULL);
     if (nivar) {
         c->ivars = (gravity_value_t *)mem_alloc(NULL, nivar * sizeof(gravity_value_t));
+        assert(c->ivars);
         for (uint32_t i=0; i<nivar; ++i) c->ivars[i] = VALUE_FROM_NULL;
     }
 
@@ -685,6 +686,7 @@ static void gravity_function_bytecode_serialize (gravity_function_t *f, json_t *
     uint32_t ninst = f->ninsts;
     uint32_t length = ninst * 2 * sizeof(uint32_t);
     uint8_t *hexchar = (uint8_t*) mem_alloc(NULL, sizeof(uint8_t) * length);
+    assert(hexchar);
 
     for (uint32_t k=0, i=0; i < ninst; ++i) {
         uint32_t value = f->bytecode[i];
@@ -1337,11 +1339,13 @@ gravity_fiber_t *gravity_fiber_new (gravity_vm *vm, gravity_closure_t *closure, 
 
     if (nstack < DEFAULT_MINSTACK_SIZE) nstack = DEFAULT_MINSTACK_SIZE;
     fiber->stack = (gravity_value_t *)mem_alloc(NULL, sizeof(gravity_value_t) * nstack);
+    assert(fiber->stack);
     fiber->stacktop = fiber->stack;
     fiber->stackalloc = nstack;
 
     if (nframes < DEFAULT_MINCFRAME_SIZE) nframes = DEFAULT_MINCFRAME_SIZE;
     fiber->frames = (gravity_callframe_t *)mem_alloc(NULL, sizeof(gravity_callframe_t) * nframes);
+    assert(fiber->frames);
     fiber->framesalloc = nframes;
     fiber->nframes = 1;
 
@@ -2384,6 +2388,7 @@ inline gravity_value_t gravity_string_to_value (gravity_vm *vm, const char *s, u
 
     uint32_t alloc = MAXNUM(len+1, DEFAULT_MINSTRING_SIZE);
     char *ptr = mem_alloc(NULL, alloc);
+    assert(ptr);
     memcpy(ptr, s, len);
 
     obj->isa = gravity_class_string;


### PR DESCRIPTION
When we try to alloc some memories and the size is directed by some variables or parameters, we should better to check ther returned pointer whether is NULL.
Because if the alloc function failed, it will return a NULL pointer. When we try to read or write the NULL pointer, it will cause `Segmentation fault (core dumped)`.  It does not provide enough information to tell what cause this crash.

We should better to check if these pointer is null.  These will make our project more robust.