### PR TITLE
fix size_t comparison of negative in file_read()

### DIFF
--- a/src/utils/gravity_utils.c
+++ b/src/utils/gravity_utils.c
@@ -147,7 +147,7 @@ const char *file_read(const char *path, size_t *len) {
     buffer[fsize] = 0;
     
     fsize2 = read(fd, buffer, (size_t)fsize);
-    if (fsize2 == -1) goto abort_read;
+    if (fsize2 != fsize) goto abort_read;
     
     if (len) *len = fsize2;
     close(fd);


### PR DESCRIPTION
size_t is unsigned, so comparison against -1 effectively causes undefined behavior

Found via UBSan (Undefined Behavior Sanitizer) in Clang 11

Fixes:
```
src/utils/gravity_utils.c:150:19: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'unsigned long' changed the value to 18446744073709551615 (64-bit, unsigned)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/utils/gravity_utils.c:150:19 in
```