### PR TITLE
fix signed char to unsigned char conversion in utf8_charbytes()

### DIFF
--- a/src/utils/gravity_utils.c
+++ b/src/utils/gravity_utils.c
@@ -469,7 +469,7 @@ end_repl_str:
  */
 
 inline uint32_t utf8_charbytes (const char *s, uint32_t i) {
-    unsigned char c = s[i];
+    unsigned char c = (unsigned char)s[i];
     
     // determine bytes needed for character, based on RFC 3629
     if ((c > 0) && (c <= 127)) return 1;


### PR DESCRIPTION
Marco, you probably recall that I'm not a strong C programmer, so take this fix with a grain of salt. I used https://wiki.sei.cmu.edu/confluence/display/c/STR34-C.+Cast+characters+to+unsigned+char+before+converting+to+larger+integer+sizes as my guide for suggesting a fix for this one. Please let me know if this is not appropriate or does not solve the problem in the right way.

Found via UBSan (Undefined Behavior Sanitizer) in Clang 11

Fixes:
```
src/utils/gravity_utils.c:473:23: runtime error: implicit conversion from type 'char' of value -27 (8-bit, signed) to type 'unsigned char' changed the value to 229 (8-bit, unsigned)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/utils/gravity_utils.c:473:23 in
```