### PR TITLE
fix uint32_t to char conversions in utf8_encode()

### DIFF
--- a/src/utils/gravity_utils.c
+++ b/src/utils/gravity_utils.c
@@ -496,37 +496,37 @@ uint32_t utf8_encode(char *buffer, uint32_t value) {
     
     if (value <= 0x7f) {
         // single byte (i.e. fits in ASCII).
-        *bytes = value & 0x7f;
+        *bytes = (char)(value & 0x7f);
         return 1;
     }
     
     if (value <= 0x7ff) {
         // two byte sequence: 110xxxxx 10xxxxxx.
-        *bytes = 0xc0 | ((value & 0x7c0) >> 6);
+        *bytes = (char)(0xc0 | ((value & 0x7c0) >> 6));
         ++bytes;
-        *bytes = 0x80 | (value & 0x3f);
+        *bytes = (char)(0x80 | (value & 0x3f));
         return 2;
     }
     
     if (value <= 0xffff) {
         // three byte sequence: 1110xxxx 10xxxxxx 10xxxxxx.
-        *bytes = 0xe0 | ((value & 0xf000) >> 12);
+        *bytes = (char)(0xe0 | ((value & 0xf000) >> 12));
         ++bytes;
-        *bytes = 0x80 | ((value & 0xfc0) >> 6);
+        *bytes = (char)(0x80 | ((value & 0xfc0) >> 6));
         ++bytes;
-        *bytes = 0x80 | (value & 0x3f);
+        *bytes = (char)(0x80 | (value & 0x3f));
         return 3;
     }
     
     if (value <= 0x10ffff) {
         // four byte sequence: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx.
-        *bytes = 0xf0 | ((value & 0x1c0000) >> 18);
+        *bytes = (char)(0xf0 | ((value & 0x1c0000) >> 18));
         ++bytes;
-        *bytes = 0x80 | ((value & 0x3f000) >> 12);
+        *bytes = (char)(0x80 | ((value & 0x3f000) >> 12));
         ++bytes;
-        *bytes = 0x80 | ((value & 0xfc0) >> 6);
+        *bytes = (char)(0x80 | ((value & 0xfc0) >> 6));
         ++bytes;
-        *bytes = 0x80 | (value & 0x3f);
+        *bytes = (char)(0x80 | (value & 0x3f));
         return 4;
     }
     


### PR DESCRIPTION
This resolves the runtime errors, but I'm quite unsure if this is the proper way to resolve the issue. I compared to the Wren source, only to notice the variable types have been changed, which may result in this type mismatch?

Found via UBSan (Undefined Behavior Sanitizer) in Clang 11

Input file:
[utf8_encode_char.txt](https://github.com/marcobambini/gravity/files/5436642/utf8_encode_char.txt)


Fixes:
```
src/utils/gravity_utils.c:518:18: runtime error: implicit conversion from type 'unsigned int' of value 170 (32-bit, unsigned) to type 'char' changed the value to -86 (8-bit, signed)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/utils/gravity_utils.c:518:18 in
```