### PR TITLE
Remove readline() from gravity utils

### DIFF
--- a/src/utils/gravity_utils.c
+++ b/src/utils/gravity_utils.c
@@ -87,35 +87,6 @@ double millitime (nanotime_t tstart, nanotime_t tend) {
     return ((double)t / 1000000.0f);
 }
 
-// MARK: - Console Functions -
-
-#ifdef WIN32
-// getline is a POSIX function not available in C on Windows (only C++)
-static ssize_t getline (char **lineptr, size_t *n, FILE *stream) {
-    // to be implemented on Windows
-    // Never use gets: it offers no protections against a buffer overflow vulnerability.
-    // see http://stackoverflow.com/questions/3302255/c-scanf-vs-gets-vs-fgets
-    // we should implement something like ggets here
-    // http://web.archive.org/web/20080525133110/http://cbfalconer.home.att.net/download/
-    
-    return -1;
-}
-#endif
-
-char *readline (char *prompt, int *length) {
-    char    *line = NULL;
-    size_t    size = 0;
-    
-    printf("%s", prompt);
-    fflush(stdout);
-    
-    ssize_t nread = getline(&line, &size, stdin);
-    if (nread == -1 || feof(stdin)) return NULL;
-    
-    *length = (int)nread;
-    return line;
-}
-
 // MARK: - I/O Functions -
 
 uint64_t file_size (const char *path) {

--- a/src/utils/gravity_utils.h
+++ b/src/utils/gravity_utils.h
@@ -27,9 +27,6 @@ nanotime_t  nanotime (void);
 double      microtime (nanotime_t tstart, nanotime_t tend);
 double      millitime (nanotime_t tstart, nanotime_t tend);
 
-// CONSOLE
-char        *readline (char *prompt, int *length);
-
 // FILE
 uint64_t    file_size (const char *path);
 const char  *file_read (const char *path, size_t *len);


### PR DESCRIPTION
This change removes `readline()` from `gravity_utils` because `getline()` isn't available on some platforms, causing fatal errors during compilation of `gravityapi`. Since REPL isn't implemented yet, `readline()` isn't used anywhere anyway.

Would be optimal to implement it as part of `gravity.c` when we get REPL in.