### PR TITLE
Add a way to pass command line arguments

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -12,3 +12,9 @@ ENV.set("VAR_KEY", "VAR_VALUE")
 // list all env variables
 var list = ENV.keys()
 ```
+
+### Class Constants
+```swift
+var max_arg = ENV.argc - 1 
+var my_arg = ENV.argv[max_arg]
+```

--- a/src/cli/gravity.c
+++ b/src/cli/gravity.c
@@ -11,6 +11,7 @@
 #include "gravity_utils.h"
 #include "gravity_core.h"
 #include "gravity_vm.h"
+#include "gravity_opt_env.h"
 
 #define DEFAULT_OUTPUT "gravity.g"
 
@@ -420,6 +421,8 @@ int main (int argc, const char* argv[]) {
 
     // create VM
     gravity_vm *vm = gravity_vm_new(&delegate);
+
+    gravity_env_register_args(vm, argc, argv);
 
     // check if input file is source code that needs to be compiled
     if ((type == OP_COMPILE) || (type == OP_COMPILE_RUN) || (type == OP_INLINE_RUN)) {

--- a/src/cli/gravity.c
+++ b/src/cli/gravity.c
@@ -422,6 +422,7 @@ int main (int argc, const char* argv[]) {
     // create VM
     gravity_vm *vm = gravity_vm_new(&delegate);
 
+    // pass argc and argv to the ENV class
     gravity_env_register_args(vm, argc, argv);
 
     // check if input file is source code that needs to be compiled

--- a/src/optionals/gravity_opt_env.c
+++ b/src/optionals/gravity_opt_env.c
@@ -99,22 +99,14 @@ static bool gravity_env_keys(gravity_vm *vm, gravity_value_t *args, uint16_t npa
     RETURN_VALUE(VALUE_FROM_OBJECT(keys), rindex);
 }
 
-static bool gravity_env_argv(gravity_vm *vm, gravity_value_t *args, uint16_t nargs, uint32_t rindex) {
-    #pragma unused(vm, args, nargs)
-    
-    if (argv)
-        RETURN_VALUE(VALUE_FROM_OBJECT(argv), rindex);
-
-    RETURN_VALUE(VALUE_FROM_NULL, rindex);
+static bool gravity_env_argc(gravity_vm *vm, gravity_value_t *args, uint16_t nargs, uint32_t rindex) {
+   #pragma unused(vm, args, nargs)
+   RETURN_VALUE((argc != -1) ? VALUE_FROM_INT(argc) : VALUE_FROM_NULL, rindex);
 }
 
-static bool gravity_env_argc(gravity_vm *vm, gravity_value_t *args, uint16_t nargs, uint32_t rindex) {
-    #pragma unused(vm, args, nargs)
-
-    if (argc != -1)
-        RETURN_VALUE(VALUE_FROM_INT(argc), rindex);
-
-    RETURN_VALUE(VALUE_FROM_NULL, rindex);
+static bool gravity_env_argv(gravity_vm *vm, gravity_value_t *args, uint16_t nargs, uint32_t rindex) {
+   #pragma unused(vm, args, nargs)
+   RETURN_VALUE((argv) ? VALUE_FROM_OBJECT(argv) : VALUE_FROM_NULL, rindex);
 }
 
 // MARK: - Internals -
@@ -132,7 +124,6 @@ static void create_optional_class (void) {
     gravity_class_bind(meta, GRAVITY_INTERNAL_LOADAT_NAME, NEW_CLOSURE_VALUE(gravity_env_get));
     gravity_class_bind(meta, GRAVITY_INTERNAL_STOREAT_NAME, NEW_CLOSURE_VALUE(gravity_env_set));
 
-    // argc and argv properties
     gravity_closure_t *closure = NULL;
     closure = computed_property_create(NULL, NEW_FUNCTION(gravity_env_argc), NULL);
     gravity_class_bind(meta, "argc", VALUE_FROM_OBJECT(closure));
@@ -153,13 +144,12 @@ void gravity_env_register(gravity_vm *vm) {
 }
 
 void gravity_env_register_args(gravity_vm *vm, uint32_t _argc, const char **_argv) {
-    gravity_value_t tmp[_argc];
-    for (int i = 0; i < _argc; ++i) {
-        tmp[i] = VALUE_FROM_CSTRING(NULL, _argv[i]);
-    }
-
     argc = _argc;
-    argv = gravity_list_from_array(vm, argc, tmp);
+    argv = gravity_list_new(vm, argc);
+    for (int i = 0; i < _argc; ++i) {
+        gravity_value_t arg = VALUE_FROM_CSTRING(vm, _argv[i]);
+        marray_push(gravity_value_t, argv->array, arg);
+    }
 }
 
 void gravity_env_free (void) {

--- a/src/optionals/gravity_opt_env.h
+++ b/src/optionals/gravity_opt_env.h
@@ -6,6 +6,7 @@
 #include "gravity_value.h"
 
 void gravity_env_register (gravity_vm *vm);
+void gravity_env_register_args(gravity_vm *vm, uint32_t _argc, const char **_argv);
 void gravity_env_free (void);
 bool gravity_isenv_class (gravity_class_t *c);
 const char *gravity_env_name (void);


### PR DESCRIPTION
This pr addresses #113 and #235 adding a way to pass arguments to the script. Unlike the approach suggested by IngwiePhoenix in #235 here the arguments are not passed to the main function but are registered as properties of the ENV class. I am unsure if the System class is more appropriate than the ENV class, but this should be chosen by the maintainer/community.

Pros of this approach:
- Arguments are accessible from anywhere in the program and not only in the main function
- Arguments are not passed directly to the vm / run function
- Passing CLI arguments is optional and require a separate register function 

Cons:
- Arguments are tight to an optional class
- To register the arguments you have to include the gravity_opt_env.h header

Possible improvements:
- Unify argc and argv to a single list called args, where argc is simply the length of the list containing argv
- Move maybe in the System class (?)

I also edited the documentation for the ENV class.
Feel free to modify this pr.

