### PR TITLE
Clang: Fixed implicit conversion from long to double

### DIFF
--- a/src/optionals/gravity_opt_math.c
+++ b/src/optionals/gravity_opt_math.c
@@ -881,7 +881,6 @@ static bool math_random (gravity_vm *vm, gravity_value_t *args, uint16_t nargs, 
     lfsr113_init((uint32_t)time(NULL));
     gravity_float_t rnd = lfsr113();
     #endif
-    
     // if at least one parameter is passed
     if (nargs > 1) {
         gravity_value_t value1 = VALUE_FROM_UNDEFINED;
@@ -906,7 +905,7 @@ static bool math_random (gravity_vm *vm, gravity_value_t *args, uint16_t nargs, 
             gravity_int_t n2 = VALUE_AS_INT(value2); // max
             if (n1 == n2) RETURN_VALUE(VALUE_FROM_INT(n1), rindex);
             
-			gravity_int_t n0 = (gravity_int_t)(rnd * GRAVITY_INT_MAX);
+			gravity_int_t n0 = (gravity_int_t)(rnd * (gravity_float_t)GRAVITY_INT_MAX);
             if (n1 > n2) {gravity_int_t temp = n1; n1 = n2; n2 = temp;} // swap numbers if min > max
             gravity_int_t n = (gravity_int_t)(n0 % (n2 + 1 - n1) + n1);
             RETURN_VALUE(VALUE_FROM_INT(n), rindex);


### PR DESCRIPTION
This simple pull request fixes an implicit conversion warning on Clang 12.0 :
```
src/optionals/gravity_opt_math.c:908:45: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-const-int-float-conversion]
 ```