### PR TITLE
fix read size different from fs-info file-size due to line-ending

### DIFF
--- a/src/utils/gravity_utils.c
+++ b/src/utils/gravity_utils.c
@@ -135,7 +135,7 @@ char *file_read(const char *path, size_t *len) {
     fsize = (off_t) file_size(path);
     if (fsize < 0) goto abort_read;
     
-    fd = open(path, O_RDONLY);
+    fd = open(path, O_RDONLY|O_BINARY);
     if (fd < 0) goto abort_read;
     
     buffer = (char *)mem_alloc(NULL, (size_t)fsize + 1);


### PR DESCRIPTION
fix line ending causing fsize != fsize2 in gravity_utils.d/file_read() due to not reading in binary mode.

On Windows when opening a file in text mode `\r` is ignored (and not read) after each `\n`. This causes files never to be loaded and giving an uninformative error just being: "`Error reading file [...]`". `\r`s are ignored by the compiler anyway.