### PR TITLE
move hash functionality

### DIFF
--- a/src/shared/gravity_hash.c
+++ b/src/shared/gravity_hash.c
@@ -481,3 +481,33 @@ cleanup:
 
     return result;
 }
+
+void gravity_hash_finteralfree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data) {
+    #pragma unused(table, key, data)
+    if (gravity_value_isobject(value)) {
+        gravity_object_t *obj = VALUE_AS_OBJECT(value);
+        if (OBJECT_ISA_CLOSURE(obj)) {
+            gravity_closure_t *closure = (gravity_closure_t *)obj;
+            if (closure->f && closure->f->tag == EXEC_TYPE_INTERNAL) gravity_function_free(NULL, closure->f);
+        }
+    }
+}
+
+void gravity_hash_keyfree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data) {
+    #pragma unused(table, value)
+    gravity_vm *vm = (gravity_vm *)data;
+    gravity_value_free(vm, key);
+}
+
+void gravity_hash_keyvaluefree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data) {
+    #pragma unused(table)
+    gravity_vm *vm = (gravity_vm *)data;
+    gravity_value_free(vm, key);
+    gravity_value_free(vm, value);
+}
+
+void gravity_hash_valuefree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data) {
+    #pragma unused(table, key)
+    gravity_vm *vm = (gravity_vm *)data;
+    gravity_value_free(vm, value);
+}

--- a/src/shared/gravity_hash.h
+++ b/src/shared/gravity_hash.h
@@ -63,6 +63,13 @@ GRAVITY_API void            gravity_hash_resetfree (gravity_hash_t *hashtable);
 
 GRAVITY_API bool            gravity_hash_compare (gravity_hash_t *hashtable1, gravity_hash_t *hashtable2, gravity_hash_compare_fn compare, void *data);
 
+// MARK: - CALLBACKS -
+// HASH FREE CALLBACK FUNCTION
+GRAVITY_API void                gravity_hash_finteralfree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data);
+GRAVITY_API void                gravity_hash_keyfree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data);
+GRAVITY_API void                gravity_hash_keyvaluefree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data);
+GRAVITY_API void                gravity_hash_valuefree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shared/gravity_value.c
+++ b/src/shared/gravity_value.c
@@ -52,36 +52,6 @@ static void gravity_hash_serialize (gravity_hash_t *table, gravity_value_t key, 
         assert(0);
 }
 
-void gravity_hash_keyvaluefree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data) {
-    #pragma unused(table)
-    gravity_vm *vm = (gravity_vm *)data;
-    gravity_value_free(vm, key);
-    gravity_value_free(vm, value);
-}
-
-void gravity_hash_keyfree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data) {
-    #pragma unused(table, value)
-    gravity_vm *vm = (gravity_vm *)data;
-    gravity_value_free(vm, key);
-}
-
-void gravity_hash_finteralfree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data) {
-    #pragma unused(table, key, data)
-    if (gravity_value_isobject(value)) {
-        gravity_object_t *obj = VALUE_AS_OBJECT(value);
-        if (OBJECT_ISA_CLOSURE(obj)) {
-            gravity_closure_t *closure = (gravity_closure_t *)obj;
-            if (closure->f && closure->f->tag == EXEC_TYPE_INTERNAL) gravity_function_free(NULL, closure->f);
-        }
-    }
-}
-
-void gravity_hash_valuefree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data) {
-    #pragma unused(table, key)
-    gravity_vm *vm = (gravity_vm *)data;
-    gravity_value_free(vm, value);
-}
-
 static void gravity_hash_internalsize (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data1, void *data2) {
     #pragma unused(table)
     uint32_t    *size = (uint32_t *)data1;

--- a/src/shared/gravity_value.h
+++ b/src/shared/gravity_value.h
@@ -573,13 +573,6 @@ GRAVITY_API void                gravity_string_free (gravity_vm *vm, gravity_str
 GRAVITY_API void                gravity_string_blacken (gravity_vm *vm, gravity_string_t *string);
 GRAVITY_API uint32_t            gravity_string_size (gravity_vm *vm, gravity_string_t *string);
 
-// MARK: - CALLBACKS -
-// HASH FREE CALLBACK FUNCTION
-GRAVITY_API void                gravity_hash_keyvaluefree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data);
-GRAVITY_API void                gravity_hash_keyfree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data);
-GRAVITY_API void                gravity_hash_valuefree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data);
-GRAVITY_API void                gravity_hash_finteralfree (gravity_hash_t *table, gravity_value_t key, gravity_value_t value, void *data);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
see #368 for more details.
In short: hash functions are expected to be in `g*_hash.h` When dynamically linking this makes more sense.