### PR TITLE
Build shared object on BSDs; remove unneeded WITH_GETLINE.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,19 +29,19 @@ else
 		LDFLAGS = -lm
 	else ifeq ($(UNAME_S),OpenBSD)
 		# OpenBSD
-		CFLAGS += -D_WITH_GETLINE
+		LIBTARGET = libgravity.so
 		LDFLAGS = -lm
 	else ifeq ($(UNAME_S),FreeBSD)
 		# FreeBSD
-		CFLAGS += -D_WITH_GETLINE
+		LIBTARGET = libgravity.so
 		LDFLAGS = -lm
 	else ifeq ($(UNAME_S),NetBSD)
 		# NetBSD
-		CFLAGS += -D_WITH_GETLINE
+		LIBTARGET = libgravity.so
 		LDFLAGS = -lm
 	else ifeq ($(UNAME_S),DragonFly)
 		# DragonFly
-		CFLAGS += -D_WITH_GETLINE
+		LIBTARGET = libgravity.so
 		LDFLAGS = -lm
 	else
 		# Linux

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,10 +59,6 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin|NetBSD|BSD|DragonFly|Linux")
     # for math functions
     list(APPEND GRAVITY_DEPENDENT_LIBS "m")
 
-    if (${CMAKE_SYSTEM_NAME} MATCHES "NetBSD|BSD|DragonFly")
-        list(APPEND GRAVITY_PRIVATE_DEFINITIONS "_WITH_GETLINE")
-    endif()
-
 endif()
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
Hello --

The BSDs are building with a -D_WITH_GETLINE switch that appears unreferenced in the code itself.
Additionally, there's no technical reason why not to build the shared library (if wanted) either, so make it available.

Thanks!