### PR TITLE
bzero is not cross-platform and deprecated.

### DIFF
--- a/src/compiler/gravity_ircode.c
+++ b/src/compiler/gravity_ircode.c
@@ -52,7 +52,7 @@ ircode_t *ircode_create (uint16_t nlocals) {
     marray_init(code->context);
 
     // init state array (register 0 is reserved)
-    bzero(code->state, MAX_REGISTERS * sizeof(bool));
+    memset(code->state, 0, MAX_REGISTERS * sizeof(bool));
     code->state[0] = true;
     for (uint32_t i=0; i<nlocals; ++i) {
         code->state[i] = true;

--- a/src/compiler/gravity_lexer.c
+++ b/src/compiler/gravity_lexer.c
@@ -533,7 +533,7 @@ gravity_lexer_t *gravity_lexer_create (const char *source, size_t len, uint32_t 
     gravity_lexer_t *lexer = mem_alloc(NULL, sizeof(gravity_lexer_t));
     if (!lexer) return NULL;
 
-    bzero(lexer, sizeof(gravity_lexer_t));
+    memset(lexer, 0, sizeof(gravity_lexer_t));
     lexer->is_static = is_static;
     lexer->lineno = 1;
     lexer->buffer = source;


### PR DESCRIPTION
 The bzero() function is deprecated (marked as LEGACY in POSIX.1-2001); use memset(3) in new programs.