### PR TITLE
Update Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/marcobambini/gravity.svg?branch=master)](https://travis-ci.org/marcobambini/gravity)
+[![Build Status](https://travis-ci.com/marcobambini/gravity.svg?branch=master)](https://travis-ci.com/marcobambini/gravity)
 
 <p align="center" >
 <img src="https://raw.githubusercontent.com/marcobambini/gravity/master/docs/assets/images/logo-gravity.png" height="74px" alt="Gravity Programming Language" title="Gravity Programming Language">


### PR DESCRIPTION
The current badge points to deprecated travis.org which redirects to travis.com, so we'd rather point to it directly :)