### PR TITLE
fix(core): move gravity_opt_free after refcount check to prevent double-free

### DIFF
--- a/src/runtime/gravity_core.c
+++ b/src/runtime/gravity_core.c
@@ -3634,13 +3634,14 @@ void gravity_core_init (void) {
 }
 
 void gravity_core_free (void) {
-    // free optionals first
-    gravity_opt_free();
-
     if (!core_inited) return;
 
     // check if others VM are still running
     if (--refcount) return;
+
+    // free optionals after refcount check — avoids double-free when mini-VM
+    // in gravity_compiler_reset() has already freed GC objects via internal_vm_cleanup
+    gravity_opt_free();
 
     // this function should never be called
     // it is just called when we need to internally check for memory leaks


### PR DESCRIPTION
`gravity_opt_free()` was called unconditionally at the top of `gravity_core_free()`, before the refcount guard. This causes a double-free when `gravity_compiler_reset()` is called before teardown.

`gravity_compiler_reset()` runs a mini-VM internally (`internal_vm_cleanup`) which frees GC objects via the GC callback — including the optionals. When `gravity_core_free()` is subsequently called, `gravity_opt_free()` then attempts to free already-freed memory.

The fix moves `gravity_opt_free()` to after the refcount check, so optionals are only freed when the last VM is being torn down.

**Reproducer:** call `gravity_compiler_reset()` on a compiler instance, then call `gravity_core_free()`. Crashes reliably under AddressSanitizer.