### PR TITLE
Fix three VM memory leaks: computed-property double creation, missing frees in gravity_core_free, orphaned GC gray-list buffer

### DIFF
--- a/src/runtime/gravity_core.c
+++ b/src/runtime/gravity_core.c
@@ -3376,8 +3376,13 @@ void gravity_core_init (void) {
     gravity_class_bind(gravity_class_object, "clone", NEW_CLOSURE_VALUE(object_clone));
 
     // INTROSPECTION support added to OBJECT CLASS
-    gravity_class_bind(gravity_class_object, "class", VALUE_FROM_OBJECT(computed_property_create(NULL, NEW_FUNCTION(object_class), NULL)));
-    gravity_class_bind(gravity_class_object, "meta", VALUE_FROM_OBJECT(computed_property_create(NULL, NEW_FUNCTION(object_meta), NULL)));
+    // NOTE: VALUE_FROM_OBJECT is a macro that can evaluate its argument twice
+    // (non GRAVITY_USE_HIDDEN_INITIALIZERS build), so computed_property_create
+    // must never be called inline inside it (it would create a leaked duplicate)
+    gravity_closure_t *object_class_closure = computed_property_create(NULL, NEW_FUNCTION(object_class), NULL);
+    gravity_class_bind(gravity_class_object, "class", VALUE_FROM_OBJECT(object_class_closure));
+    gravity_closure_t *object_meta_closure = computed_property_create(NULL, NEW_FUNCTION(object_meta), NULL);
+    gravity_class_bind(gravity_class_object, "meta", VALUE_FROM_OBJECT(object_meta_closure));
     gravity_class_bind(gravity_class_object, "respondTo", NEW_CLOSURE_VALUE(object_respond));
     gravity_class_bind(gravity_class_object, "methods", NEW_CLOSURE_VALUE(object_methods));
     gravity_class_bind(gravity_class_object, "properties", NEW_CLOSURE_VALUE(object_properties));
@@ -3481,8 +3486,10 @@ void gravity_core_init (void) {
     gravity_class_t *int_meta = gravity_class_get_meta(gravity_class_int);
     gravity_class_bind(int_meta, "random", NEW_CLOSURE_VALUE(int_random));
     gravity_class_bind(int_meta, GRAVITY_INTERNAL_EXEC_NAME, NEW_CLOSURE_VALUE(int_exec));
-    gravity_class_bind(int_meta, "min", VALUE_FROM_OBJECT(computed_property_create(NULL, NEW_FUNCTION(int_min), NULL)));
-    gravity_class_bind(int_meta, "max", VALUE_FROM_OBJECT(computed_property_create(NULL, NEW_FUNCTION(int_max), NULL)));
+    gravity_closure_t *int_min_closure = computed_property_create(NULL, NEW_FUNCTION(int_min), NULL);
+    gravity_class_bind(int_meta, "min", VALUE_FROM_OBJECT(int_min_closure));
+    gravity_closure_t *int_max_closure = computed_property_create(NULL, NEW_FUNCTION(int_max), NULL);
+    gravity_class_bind(int_meta, "max", VALUE_FROM_OBJECT(int_max_closure));
     
     // FLOAT CLASS
     gravity_class_bind(gravity_class_float, GRAVITY_OPERATOR_ADD_NAME, NEW_CLOSURE_VALUE(operator_float_add));
@@ -3506,8 +3513,10 @@ void gravity_core_init (void) {
     // Meta
     gravity_class_t *float_meta = gravity_class_get_meta(gravity_class_float);
     gravity_class_bind(float_meta, GRAVITY_INTERNAL_EXEC_NAME, NEW_CLOSURE_VALUE(float_exec));
-    gravity_class_bind(float_meta, "min", VALUE_FROM_OBJECT(computed_property_create(NULL, NEW_FUNCTION(float_min), NULL)));
-    gravity_class_bind(float_meta, "max", VALUE_FROM_OBJECT(computed_property_create(NULL, NEW_FUNCTION(float_max), NULL)));
+    gravity_closure_t *float_min_closure = computed_property_create(NULL, NEW_FUNCTION(float_min), NULL);
+    gravity_class_bind(float_meta, "min", VALUE_FROM_OBJECT(float_min_closure));
+    gravity_closure_t *float_max_closure = computed_property_create(NULL, NEW_FUNCTION(float_max), NULL);
+    gravity_class_bind(float_meta, "max", VALUE_FROM_OBJECT(float_max_closure));
 
     // BOOL CLASS
     gravity_class_bind(gravity_class_bool, GRAVITY_OPERATOR_ADD_NAME, NEW_CLOSURE_VALUE(operator_bool_add));
@@ -3658,6 +3667,19 @@ void gravity_core_free (void) {
     computed_property_free(gravity_class_float, "degrees", true);
     gravity_class_t *system_meta = gravity_class_get_meta(gravity_class_system);
     computed_property_free(system_meta, GRAVITY_VM_GCENABLED, true);
+    // these computed properties are also created in gravity_core_init but were
+    // missing from this free list (leaked on every core init/free cycle)
+    computed_property_free(gravity_class_object, "class", true);
+    computed_property_free(gravity_class_object, "meta", true);
+    computed_property_free(gravity_class_range, "from", true);
+    computed_property_free(gravity_class_range, "to", true);
+    computed_property_free(gravity_class_string, "bytes", true);
+    gravity_class_t *int_meta_cp = gravity_class_get_meta(gravity_class_int);
+    computed_property_free(int_meta_cp, "min", true);
+    computed_property_free(int_meta_cp, "max", true);
+    gravity_class_t *float_meta_cp = gravity_class_get_meta(gravity_class_float);
+    computed_property_free(float_meta_cp, "min", true);
+    computed_property_free(float_meta_cp, "max", true);
 
     gravity_class_free_core(NULL, gravity_class_get_meta(gravity_class_int));
     gravity_class_free_core(NULL, gravity_class_int);

--- a/src/runtime/gravity_vm.c
+++ b/src/runtime/gravity_vm.c
@@ -1543,12 +1543,15 @@ gravity_vm *gravity_vm_new (gravity_delegate_t *delegate) {
     vm->context = gravity_hash_create(DEFAULT_CONTEXT_SIZE, gravity_value_hash, gravity_value_equals, NULL, NULL);
 
     // garbage collector
+    // graylist/gctemp MUST be initialized before gravity_gc_setenabled: enabling the GC
+    // can trigger a collection that grows the graylist buffer, and a marray_init after
+    // that would zero the pointer and orphan (leak) the allocation.
+    marray_init(vm->graylist);
+    marray_init(vm->gctemp);
     gravity_gc_setenabled(vm, true);
     gravity_gc_setvalues(vm, DEFAULT_CG_THRESHOLD, DEFAULT_CG_MINTHRESHOLD, DEFAULT_CG_RATIO);
     vm->memallocated = 0;
     vm->maxmemblock = MAX_MEMORY_BLOCK;
-    marray_init(vm->graylist);
-    marray_init(vm->gctemp);
 
     // init base and core
     gravity_core_register(vm);


### PR DESCRIPTION
Found while running an embedding host (repeated compile/run/free cycles) under AddressSanitizer/LeakSanitizer. Three distinct leaks, all reproducible with a minimal embed loop (below):

## 1. Computed properties created twice in `gravity_core_init` (double macro expansion)

When `GRAVITY_USE_HIDDEN_INITIALIZERS` is not set, `VALUE_FROM_OBJECT()` evaluates its argument twice:

```c
#define VALUE_FROM_OBJECT(obj) ((gravity_value_t){.isa = ((gravity_object_t *)(obj)->isa), .p = (gravity_object_t *)(obj)})
```

Six bind sites in `gravity_core_init` call `computed_property_create()` inline inside that macro (`Object.class`, `Object.meta`, `Int` meta `min`/`max`, `Float` meta `min`/`max`). Each of those computed properties is therefore created **twice** — one copy gets bound, the duplicate is orphaned immediately (~2.2KB leaked per `gravity_core_init`, even without ever freeing the core). The fix uses the same temp-variable pattern the rest of `gravity_core_init` already uses for every other computed property, plus a comment warning against calling `computed_property_create` inline inside the macro.

## 2. Nine computed properties missing from `gravity_core_free`'s manual free list

`gravity_core_free` manually frees `List.count`, `Map.count`, `Range.count`, `String.length`, `Int/Float.radians/degrees`, and `System.gcEnabled` — but not `Object.class`, `Object.meta`, `Range.from`, `Range.to`, `String.bytes`, `Int` meta `min`/`max`, or `Float` meta `min`/`max`, which `gravity_core_init` also creates. Each core init/free cycle leaked these (~3.3KB per cycle for hosts that restart the script engine).

## 3. GC gray-list buffer orphaned in `gravity_vm_new`

`gravity_vm_new` calls `gravity_gc_setenabled(vm, true)` *before* `marray_init(vm->graylist)`. Enabling the GC can trigger a collection (`gravity_gc_check` → `gravity_gc_start`), which grows the gray-list buffer via `marray_push`/`realloc` — and the `marray_init` that follows zeroes the array struct, orphaning that buffer (one buffer leaked per VM). Fixed by initializing `graylist`/`gctemp` before enabling the GC.

## Repro

```c
for (int i = 0; i < 3; ++i) {
    gravity_delegate_t delegate = { .error_callback = report_error };
    gravity_compiler_t *compiler = gravity_compiler_create(&delegate);
    gravity_closure_t *closure = gravity_compiler_run(compiler, source, strlen(source), 0, true, true);
    gravity_vm *vm = gravity_vm_new(&delegate);
    gravity_compiler_transfer(compiler, vm);
    gravity_compiler_free(compiler);
    if (closure) { gravity_vm_runmain(vm, closure); gravity_gc_start(vm); }
    gravity_vm_free(vm);
    gravity_core_free();
}
```

Built with `-fsanitize=address`: **before** — `SUMMARY: AddressSanitizer: 22296 byte(s) leaked in 156 allocation(s)`; **after** — clean exit, zero leaks.

## Testing

- `make && test/unittest/run_all.sh`: **350/350 pass, 0 failed, 0 timed out** with the patches applied.
- The ASan embed loop above runs leak-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)