### PR TITLE
fix(json): avoid signed overflow on integers too large for int64

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,4 @@ Brandon Ray   <brandon@bombsightgames.com>
 Filippo Costa <filippocosta.italy@gmail.com>
 Matan Silver  <matansilver@gmail.com>
 Martin Miralles-Cordal <axalon@rutgers.edu>
+Ivan Teresenko <0630039863abc@gmail.com>

--- a/src/utils/gravity_json.c
+++ b/src/utils/gravity_json.c
@@ -423,6 +423,11 @@ static unsigned char hex_value (json_char c)
    }
 }
 
+static int would_overflow (json_int_t value, json_char b)
+{
+   return ((JSON_INT_MAX - (b - '0')) / 10 ) < value;
+}
+
 typedef struct
 {
    unsigned long used_memory;
@@ -583,7 +588,8 @@ static const long
    flag_num_e_got_sign   = 1 << 11,
    flag_num_e_negative   = 1 << 12,
    flag_line_comment     = 1 << 13,
-   flag_block_comment    = 1 << 14;
+   flag_block_comment    = 1 << 14,
+   flag_num_got_decimal  = 1 << 15;
 
 json_value * json_parse_ex (json_settings * settings,
                             const json_char * json,
@@ -596,7 +602,7 @@ json_value * json_parse_ex (json_settings * settings,
    json_state state = EMPTY_STATE_STRUCT;
    long flags;
    long num_digits = 0, num_e = 0;
-   json_int_t num_fraction = 0;
+   double num_fraction = 0;
 
    /* Skip UTF-8 BOM
     */
@@ -1123,11 +1129,25 @@ json_value * json_parse_ex (json_settings * settings,
                         continue;
                      }
 
+                     if (would_overflow (top->u.integer, b))
+                     {
+                        json_int_t integer = top->u.integer;
+                        -- num_digits;
+                        -- state.ptr;
+                        top->type = json_double;
+                        top->u.dbl = (double)integer;
+                        continue;
+                     }
+
                      top->u.integer = (top->u.integer * 10) + (b - '0');
                      continue;
                   }
 
-                  num_fraction = (num_fraction * 10) + (b - '0');
+                  if (flags & flag_num_got_decimal)
+                     num_fraction = (num_fraction * 10) + (b - '0');
+                  else
+                     top->u.dbl = (top->u.dbl * 10) + (b - '0');
+
                   continue;
                }
 
@@ -1153,6 +1173,7 @@ json_value * json_parse_ex (json_settings * settings,
                   top->type = json_double;
                   top->u.dbl = (double) top->u.integer;
 
+                  flags |= flag_num_got_decimal;
                   num_digits = 0;
                   continue;
                }
@@ -1166,7 +1187,7 @@ json_value * json_parse_ex (json_settings * settings,
                         goto e_failed;
                      }
 
-                     top->u.dbl += ((double) num_fraction) / (pow (10.0, (double) num_digits));
+                     top->u.dbl += num_fraction / (pow (10.0, (double) num_digits));
                   }
 
                   if (b == 'e' || b == 'E')

--- a/src/utils/gravity_json.h
+++ b/src/utils/gravity_json.h
@@ -96,6 +96,10 @@ void        json_set_option (json_t *json, json_opt_mask option_value);
    #endif
 #endif
 
+#ifndef JSON_INT_MAX
+   #define JSON_INT_MAX INT64_MAX
+#endif
+
 #include <stdlib.h>
 
 #ifdef __cplusplus

--- a/test/unittest/bugfix_json_integer_overflow.gravity
+++ b/test/unittest/bugfix_json_integer_overflow.gravity
@@ -1,0 +1,31 @@
+#unittest {
+	name: "JSON.parse with integers too large for int64.";
+	error: NONE;
+	result: true;
+};
+
+func main() {
+	// A digit run that does not fit in a signed 64-bit integer must not
+	// overflow while being accumulated. The value degrades to a float,
+	// the same way it already does when a '.' or an exponent is seen.
+	var big = JSON.parse('{"v":2222222222222222222222222}');
+	if (big["v"] < 2.0e24) return false;
+	if (big["v"] > 2.3e24) return false;
+
+	// One digit past INT64_MAX (9223372036854775807).
+	var over = JSON.parse('{"v":92233720368547758070}');
+	if (over["v"] < 9.2e19) return false;
+
+	// Negative values overflow through the same accumulator.
+	var neg = JSON.parse('{"v":-2222222222222222222222222}');
+	if (neg["v"] > -2.0e24) return false;
+
+	// Values that still fit must keep their exact integer value.
+	var exact = JSON.parse('{"v":9223372036854775807}');
+	if (exact["v"] != 9223372036854775807) return false;
+
+	var small = JSON.parse('{"v":42}');
+	if (small["v"] != 42) return false;
+
+	return true;
+}


### PR DESCRIPTION
_Disclosure: this patch was prepared with AI assistance (Claude Opus 5). I built the project, reproduced the overflow under UBSan and checked the result against upstream json-parser myself before opening this._

Fixes #447.

### The bug

`json_parse_ex` accumulates integer literals with no bound check:

```c
top->u.integer = (top->u.integer * 10) + (b - '0');
```

A digit run longer than the `int64_t` range overflows. Signed overflow is undefined behaviour, and UBSan reports it directly:

```
src/utils/gravity_json.c:1126:55: runtime error: signed integer overflow:
2222222222222222222 * 10 cannot be represented in type 'int64_t'
```

Reachable from `JSON.parse` in Gravity code, and from `json_parse()` / `gravity_vm_loadbuffer()` in the C API.

### The fix

This file is vendored from [json-parser](https://github.com/udp/json-parser) (per the header comment), and **upstream already fixed this** — Gravity just never picked it up. So this is a backport rather than a new invention.

Upstream detects the overflow before it happens and degrades the value to a double, which is the same thing the parser already does when it sees a `.` or an exponent. Rejecting the input was not an option: such literals are valid per RFC 8259, and both Python and JavaScript accept them.

Carrying that fix over needed one more piece. Gravity told the integer and fraction parts apart by `top->type` alone, so once the value flipped to `json_double` the remaining digits were misread as a fraction and the magnitude was silently lost — `2.2e18` instead of `2.2e24`. Upstream distinguishes the two with a `flag_num_got_decimal` flag, so that came across too. Making `num_fraction` a `double` also matches upstream and removes a second overflow in the same accumulator.

Trading undefined behaviour for a quietly wrong number did not seem like a good deal, hence the slightly wider diff.

### Verification

Built with `-fsanitize=undefined -fno-sanitize-recover=signed-integer-overflow`:

| | before | after |
|---|---|---|
| `signed integer overflow` at json.c:1126 | reported | gone |

Checked against upstream json-parser compiled separately, same input — both now yield `2.22222e+24`.

Values behave as expected:

```
{"v":2222222222222222222222222}   -> 2.22222e+24
{"v":92233720368547758070}        -> 9.22337e+19
{"v":-2222222222222222222222222}  -> -2.22222e+24
{"v":9223372036854775807}         -> 9223372036854775807  (exact, still an integer)
{"v":42}                          -> 42
```

- `test/unittest/bugfix_json_integer_overflow.gravity` added, per the testing rule in CONTRIBUTING.md. It fails without the code change and passes with it — verified by reverting only the code and keeping the test.
- Full suite: **351/351, 0 failures**, on both the debug and the plain `make` build.
- Two other UBSan reports show up on this input (`gravity_json.c` null-pointer arithmetic in the two-pass sizing scheme, and a misaligned load in `gravity_hash.c`). Both reproduce on a clean `master` without this patch, so they are pre-existing and left alone.

Added myself to CONTRIBUTORS as the contributing guide asks.
